### PR TITLE
add tertiary41 files

### DIFF
--- a/bin/desi_fba_tertiary_0041
+++ b/bin/desi_fba_tertiary_0041
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+
+import os
+import fitsio
+import numpy as np
+from astropy.io import fits
+from astropy.table import Table, vstack
+from desiutil.log import get_logger
+from desiutil.redirect import stdouterr_redirected
+from desisurveyops.fba_tertiary_design_io import (
+    assert_environ_settings,
+    get_fn,
+    read_yaml,
+    assert_tertiary_settings,
+    get_tile_centers_grid,
+    create_tiles_table,
+    creates_priority_table,
+    finalize_target_table,
+    assert_files,
+    create_targets_assign,
+    plot_targets_assign,
+)
+from desitarget.targetmask import desi_mask, bgs_mask
+from argparse import ArgumentParser
+
+# AR message to ensure that some key settings in the environment are correctly set
+# AR put it at the very top, so that it appears first, and is not redirected
+# AR    (=burried) in the log file
+assert_environ_settings()
+
+log = get_logger()
+
+
+def parse():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--yamlfn",
+        help="path to the tertiary-config-PROGNUMPAD.yaml file",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--steps",
+        help="comma-separated list of steps to execute (default='tiles,priorities,targets,run,diagnosis')",
+        type=str,
+        default="tiles,priorities,targets,run,diagnosis",
+    )
+    parser.add_argument(
+        "--dry_run",
+        action="store_true",
+        help="for the 'run' step, only print the commands on the prompt",
+    )
+    parser.add_argument(
+        "--log-stdout",
+        "--log_stdout",
+        action="store_true",
+        help="log to stdout instead of redirecting to a file",
+    )
+    args = parser.parse_args()
+    for kwargs in args._get_kwargs():
+        log.info("{} = {}".format(kwargs[0], kwargs[1]))
+    return args
+
+
+# AR 4 tiles
+# AR see email from Noah W. from 2024-07-10 2:50PM
+def create_tiles(tileid_start, ntile, obsconds, outfn):
+    tileids = np.arange(tileid_start, tileid_start + ntile, dtype=int)
+    tileras = np.array([333.0, 346.0, 350.0, 357.2])
+    tiledecs = np.array([1.5, 1.5, 1.5, 1.5])
+    assert tileras.size == ntile
+    assert tiledecs.size == ntile
+    d = create_tiles_table(tileids, tileras, tiledecs, obsconds)
+    d.write(outfn)
+
+
+# AR usual priority scheme (+1 when observed)
+def create_priorities(yamlfn, outfn):
+    d = creates_priority_table(yamlfn)
+    # AR print
+    d.pprint_all()
+    for sample in np.unique(d["TERTIARY_TARGET"]):
+        sel = d["TERTIARY_TARGET"] == sample
+        log.info("priorites for {}: {}".format(sample, d["PRIORITY"][sel].tolist()))
+    d.write(outfn)
+
+
+# see emails from Christophe and Noah W. from 2024-07-10
+def create_targets(yamlfn, outfn):
+    # AR input cat
+    targdir = read_yaml(yamlfn)["settings"]["targdir"]
+    mydict = read_yaml(yamlfn)["samples"]
+    fns = np.unique([mydict[sample]["FN"] for sample in mydict])
+    assert np.all(
+        fns == np.array([
+            "des_mly3.fits",
+            "new_qso_lya__eq_stripe_targets-20240710-nomainqso.fits",
+        ])
+    )
+    ds = []
+    for fn in fns:
+        count = 0
+        d = Table(fitsio.read(os.path.join(targdir, "inputcats", fn)))
+        # AR PMRA,DEC, REF_EPOCH
+        d["PMRA"], d["PMDEC"], d["REF_EPOCH"] = 0., 0., 2015.5
+        # AR get TERTIARY_TARGET
+        d["TERTIARY_TARGET"] = np.zeros(len(d), dtype=object)
+        samples = [sample for sample in mydict if mydict[sample]["FN"] == fn]
+        prioinits = [mydict[sample]["PRIORITY_INIT"] for sample in samples]
+        for sample, prioinit in zip(samples, prioinits):
+            if fn == "new_qso_lya__eq_stripe_targets-20240710-nomainqso.fits":
+                sel = np.ones(len(d), dtype=bool)
+            if fn == "des_mly3.fits":
+                sel = d["SAMPLE"] == sample
+            d["TERTIARY_TARGET"][sel] = sample
+            count += sel.sum()
+            log.info(
+                "{}\t: assign {}/{} targets to {}".format(fn, sel.sum(), len(d), sample)
+            )
+        assert count == len(d)
+        # ORIG_ROW, ORIG_FN
+        d["ORIG_ROW"] = np.arange(len(d), dtype=int)
+        d["ORIG_FN"] = np.array([fn for _ in d], dtype=object)
+        keep_keys = [
+            "RA",
+            "DEC",
+            "PMRA",
+            "PMDEC",
+            "REF_EPOCH",
+            "TERTIARY_TARGET",
+            "ORIG_ROW",
+            "ORIG_FN",
+        ]
+        d = d[keep_keys]
+        ds.append(d)
+    d = vstack(ds)
+    d["TERTIARY_TARGET"] = d["TERTIARY_TARGET"].astype(str)
+    d["ORIG_FN"] = d["ORIG_FN"].astype(str)
+    # AR finalize
+    d = finalize_target_table(d, yamlfn)
+    d.meta["RANDSEED"] = read_yaml(yamlfn)["settings"]["np_rand_seed"]
+    d.write(outfn)
+
+
+def main():
+
+    # AR read + assert settings
+    mydict = read_yaml(args.yamlfn)["settings"]
+    assert_tertiary_settings(mydict)
+    prognum, targdir = mydict["prognum"], mydict["targdir"]
+
+    # AR set random seed (for SUBPRIORITY reproducibility)
+    np.random.seed(mydict["np_rand_seed"])
+
+    # AR tiles file
+    if "tiles" in args.steps.split(","):
+        tilesfn = get_fn(prognum, "tiles", targdir)
+        log.info("run create_tiles() to generate {}".format(tilesfn))
+        create_tiles(
+            mydict["tileid_start"], mydict["ntile"], mydict["obsconds"], tilesfn
+        )
+
+    # AR priorities file
+    if "priorities" in args.steps.split(","):
+        priofn = get_fn(prognum, "priorities", targdir)
+        log.info("run create_priorities() to generate {}".format(priofn))
+        create_priorities(args.yamlfn, priofn)
+
+    # AR targets file
+    if "targets" in args.steps.split(","):
+        targfn = get_fn(prognum, "targets", targdir)
+        log.info("run create_targets() to generate {}".format(targfn))
+        create_targets(args.yamlfn, targfn)
+
+    # AR sanity checks + run
+    if "run" in args.steps.split(","):
+        assert_files(prognum, targdir)
+        cmd = "desi_fba_tertiary_wrapper --prognum {} --targdir {} --rundate {} --std_dtver {}".format(
+            prognum, targdir, mydict["rundate"], mydict["std_dtver"]
+        )
+        if args.dry_run:
+            cmd = "{} --dry_run".format(cmd)
+        log.info(cmd)
+        os.system(cmd)
+
+    # AR diagnosis
+    if "diagnosis" in args.steps.split(","):
+        create_targets_assign(prognum, targdir)
+        plot_targets_assign(prognum, targdir)
+
+
+if __name__ == "__main__":
+
+    args = parse()
+
+    if args.log_stdout:
+        main()
+    else:
+        _ = read_yaml(args.yamlfn)["settings"]
+        logfn = get_fn(_["prognum"], "log", _["targdir"])
+        with stdouterr_redirected(to=logfn):
+            main()

--- a/data/tertiary-config-0041.yaml
+++ b/data/tertiary-config-0041.yaml
@@ -1,0 +1,22 @@
+# overall settings
+settings:
+    prognum : 41
+    targdir : "DESIROOT/survey/fiberassign/special/tertiary/0041"
+    ntile : 4
+    tileid_start : 83475
+    rundate : "2024-07-10T17:00:00+00:00"
+    obsconds : "DARK"
+    sbprof : "ELG"
+    goaltime : 1000
+    std_dtver : "1.1.1"
+    np_rand_seed : 1234
+
+# per-sample settings
+samples:
+    CFIS_LYA : {"PRIORITY_INIT" : 9000, "NGOAL" : 1, "CHECKER" : "CY", "FN" : "new_qso_lya__eq_stripe_targets-20240710-nomainqso.fits"}
+    DES_MLY3_HI : {"PRIORITY_INIT" : 8000, "NGOAL" : 1, "CHECKER" : "NW", "FN" : "des_mly3.fits"}
+    DES_MLY3_LO : {"PRIORITY_INIT" : 7500, "NGOAL" : 1, "CHECKER" : "NW", "FN" : "des_mly3.fits"}
+    DES_MLY3_FILLER : {"PRIORITY_INIT" : 6000, "NGOAL" : 1, "CHECKER" : "NW", "FN" : "des_mly3.fits"}
+    DES_MLY3_FILLER2 : {"PRIORITY_INIT" : 5500, "NGOAL" : 1, "CHECKER" : "NW", "FN" : "des_mly3.fits"}
+    DES_MLY3_FILLER3 : {"PRIORITY_INIT" : 5000, "NGOAL" : 1, "CHECKER" : "NW", "FN" : "des_mly3.fits"}
+    DES_MLY3_FILLER4 : {"PRIORITY_INIT" : 4500, "NGOAL" : 1, "CHECKER" : "NW", "FN" : "des_mly3.fits"}


### PR DESCRIPTION
This PR adds the script + configuration file used to design the tertiary41 tiles.
Those are four dark tiles (83475-78), with CFIS_LYA targets at top priority, then DES_MLY3 targets at lower priority.
Tiles 83476-8 have been observed on 20240712.