### PR TITLE
Revert cron to desired job time

### DIFF
--- a/.github/workflows/monthlyops.yml
+++ b/.github/workflows/monthlyops.yml
@@ -1,9 +1,8 @@
 name: Monthly Ops
 on:
   schedule:
-    # Scheduled time day 1 of month, 15:33 UTC
-    # - cron: 33 15 1 * *
-    - cron: 59 14 13 * *
+    # Scheduled time: day 1 of month, 15:33 UTC / 07:33 PST
+    - cron: 33 15 1 * *
 
 jobs:
   create_issue:


### PR DESCRIPTION
Test of cronjob was successful, so switch the date of this job to the first day of each month at 15:33 UT. The seemingly arbitrary time is because of high load times at the start of every hour. [See documentation here](https://docs.github.com/en/actions/use-cases-and-examples/project-management/scheduling-issue-creation) for details.