### PR TITLE
Add single script to generate monthly status plot

### DIFF
--- a/bin/make_monthly_plot
+++ b/bin/make_monthly_plot
@@ -9,7 +9,7 @@ log = get_logger()
 
 from argparse import ArgumentParser
 ap = ArgumentParser(description=("Generates monthly status plot. For example:"
-                    "make_monthly_plot 20240725 20240826 $SCRATCH")
+                    " make_monthly_plot 20240725 20240826 $SCRATCH")
                     )
 ap.add_argument("nightbegin",
                 help=("First night of interest (YYYYMMDD). Typically a month "
@@ -19,7 +19,9 @@ ap.add_argument("nightend",
                 help=("Final night of interest (YYYYMMDD). Typically today.")
                 )
 ap.add_argument("desisurveyoutput",
-                help=("Directory to write plots and ephemeris files")
+                help=("Directory to write plots and ephemerides file. The "
+                "ephemerides file will be cached in this directory (so the code "
+                "will run faster if you use a consistent desisurveyoutput).")
                 )
 
 ns = ap.parse_args()

--- a/bin/make_monthly_plot
+++ b/bin/make_monthly_plot
@@ -2,7 +2,6 @@
 
 import os
 from desisurvey import forecast
-from importlib import reload
 import matplotlib.pyplot as plt
 
 from desiutil.log import get_logger
@@ -38,8 +37,6 @@ _ = os.system("svn up $SURVEYOPS/ops")
 os.environ['DESISURVEY_OUTPUT'] = ns.desisurveyoutput
 
 plt.clf()
-
-reload(forecast)
 
 # ADM local location of config-main-nominal.yaml file.
 cfgfile = '../data/config-main-nominal.yaml'

--- a/bin/make_monthly_plot
+++ b/bin/make_monthly_plot
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+import os
+from desisurvey import forecast
+from importlib import reload
+import matplotlib.pyplot as plt
+
+from desiutil.log import get_logger
+log = get_logger()
+
+from argparse import ArgumentParser
+ap = ArgumentParser(description=("Generates monthly status plot. For example:"
+                    "make_monthly_plot 20240725 20240826 $SCRATCH")
+                    )
+ap.add_argument("nightbegin",
+                help=("First night of interest (YYYYMMDD). Typically a month "
+                "before nightend.")
+                )
+ap.add_argument("nightend",
+                help=("Final night of interest (YYYYMMDD). Typically today.")
+                )
+ap.add_argument("desisurveyoutput",
+                help=("Directory to write plots and ephemeris files")
+                )
+
+ns = ap.parse_args()
+
+# ADM $SURVEYOPS environment variable must be defined.
+surveyopsdir = os.environ.get('SURVEYOPS')
+if surveyopsdir is None:
+    msg = '$SURVEYOPS environment variable is not defined!'
+    log.critical(msg)
+    raise NameError(msg)
+
+log.info('Updating $SURVEYOPS/ops directory...')
+_ = os.system("svn up $SURVEYOPS/ops")
+
+os.environ['DESISURVEY_OUTPUT'] = ns.desisurveyoutput
+
+plt.clf()
+
+reload(forecast)
+
+# ADM local location of config-main-nominal.yaml file.
+cfgfile = '../data/config-main-nominal.yaml'
+log.info(f'Using local cfgfile in {cfgfile}')
+
+# ADM run the code.
+forecast.summarize_daterange(ns.nightbegin, ns.nightend, cfgfile=cfgfile,
+                             surveyopsdir=surveyopsdir)
+
+# ADM make the plot.
+p = forecast.forecast_plots(cfgfile=cfgfile, surveyopsdir=surveyopsdir,
+                            nownight=ns.nightbegin, return_plot=True)
+
+plotfn = os.path.join(ns.desisurveyoutput, f'{ns.nightbegin}.png')
+log.info(f'Writing monthly status plot to {plotfn}')
+p.savefig(plotfn)

--- a/data/config-main-nominal.yaml
+++ b/data/config-main-nominal.yaml
@@ -1,0 +1,475 @@
+####################################################################
+
+# Configuration data for DESI survey planning and scheduling.
+
+####################################################################
+
+
+
+survey: main
+
+
+
+#-------------------------------------------------------------------
+
+# Location of the Mayall at KPNO
+
+#-------------------------------------------------------------------
+
+
+
+location:
+
+    latitude: 31.963972222 deg
+
+    longitude: -111.599336111 deg
+
+    elevation: 2120 m
+
+    pressure: 78318 Pa    # from 1976 standard atmosphere model
+
+    temperature: 5 C      # a guess at mean night-time temperature
+
+    timezone: US/Arizona
+
+
+
+#-------------------------------------------------------------------
+
+# Observing calendar.
+
+#-------------------------------------------------------------------
+
+
+
+# Survey nominally starts on night of this date. Format is YYYY-MM-DD.
+
+first_day: 2021-05-14
+
+
+
+# Survey nominally ends on morning of this date. Format is YYYY-MM-DD.
+
+last_day: 2026-05-14
+
+
+
+# Nominal monsoon shutdown start/stop dates each year.
+
+# Start date marks first night of monsoon shutdown each year.
+
+# Observing resumes on night of the stop date. Format is YYYY-MM-DD.
+
+monsoon:
+
+    Y2020:
+
+        start: 2020-07-27
+
+        stop:  2020-08-14
+
+# actual shutdown
+
+#     Y2021:
+
+#         start: 2021-07-10
+
+#        stop:  2021-09-20
+
+# nominal three week shutdown
+
+    Y2021:
+
+        start: 2021-08-09
+
+        stop: 2021-08-27
+
+# nominal three week shutdown
+
+    Y2022:
+
+        start: 2022-08-01
+
+        stop: 2022-08-19
+
+# actual shutdown; end date currently unknown!
+
+#    Y2022:
+
+#        start: 2022-06-13
+
+#        stop: 2022-09-05
+
+    Y2023:
+
+        start: 2023-07-24
+
+        stop:  2023-08-11
+
+    Y2024:
+
+        start: 2024-07-08
+
+        stop:  2024-07-26
+
+    Y2025:
+
+        start: 2025-07-28
+
+        stop:  2025-08-15
+
+
+
+# Number of nights reserved for engineering / guest observing
+
+# during each full moon.
+
+full_moon_nights: 4
+
+
+
+programs:
+
+    DARK:
+
+        min_exposures: 1
+
+        efftime: 1000 s
+
+        conditions: DARK
+
+        sbprof: ELG
+
+        mintime: 5 min
+
+        efftime_type: DARK
+
+        expfac_cut: 2.5
+
+    BRIGHT:
+
+        min_exposures: 1
+
+        efftime: 180 s
+
+        conditions: BRIGHT
+
+        sbprof: BGS
+
+        mintime: 3 min
+
+        efftime_type: BRIGHT
+
+        # Never observe in BACKUP at present.
+
+        expfac_cut: 12.0
+
+    BACKUP:
+
+        min_exposures: 1
+
+        efftime: 60 s
+
+        conditions: BACKUP
+
+        sbprof: PSF
+
+        mintime: 1 min
+
+        efftime_type: BRIGHT
+
+
+
+min_exposures: 1
+
+
+
+# note: conditions controls only the sky brightness in the survey sims,
+
+# and the labeling of conditions in the ephemerides file.
+
+# the DARK/GRAY/BRIGHT naming is only ~coincidental to the corresponding
+
+# program names at this point.
+
+conditions:
+
+    DARK:
+
+        # Twilight requirement.
+
+        max_sun_altitude: -15 deg
+
+        # Moon must be below the horizon.
+
+        moon_up_factor: 1.0
+
+        boost_factor: 1.0
+
+    GRAY:
+
+        # Twilight requirement is the same as DARK.
+
+        # Moon must be above the horizon and pass both of these cuts:
+
+        max_moon_illumination: 0.6
+
+        max_moon_illumination_altitude_product: 30 deg
+
+        moon_up_factor: 1.5
+
+        boost_factor: 1.0
+
+    BRIGHT:
+
+        # Twilight requirement.
+
+        max_sun_altitude: -12 deg
+
+        # Any time after twilight that is neither DARK nor GRAY is BRIGHT.
+
+        moon_up_factor: 3.6
+
+        boost_factor: 1.0
+
+    BACKUP:
+
+        boost_factor 1.0
+
+
+
+#-------------------------------------------------------------------
+
+# Parameters to plan next-tile selection during each night.
+
+#-------------------------------------------------------------------
+
+
+
+# Never observe below this limit.
+
+min_altitude: 30 deg
+
+
+
+# Never observe at larger HA than 5 hr.
+
+max_hour_angle: 75 deg
+
+
+
+# Time required to setup for a new field, including slew, fiber positioning, etc.
+
+new_field_setup : 139 s
+
+
+
+# Time required to setup for re-observing the same field.
+
+same_field_setup : 70 s
+
+# Maximum time allowed for a single exposure before we force a cosmic split.
+
+cosmic_ray_split: 30 min
+
+
+
+# Maximum time to sit on one tile
+
+maxtime: 90 min
+
+
+
+# Boost priority of already started tiles
+
+finish_started_priority: 0.1
+
+
+
+# Do not boost priority of later passes.
+
+boost_priority_by_passnum: 0.00
+
+
+
+# SFD coefficient
+
+ebv_coefficient: 2.165
+
+
+
+# Reduce priority of completed tiles
+
+# Do not repeat finished tiles.
+
+ignore_completed_priority: -1
+
+
+
+# Boost priority of tiles with completed neighbors.
+
+# A fully surrounded gets a boost to priority by one plus this fraction.
+
+adjacency_priority: 0.08
+
+
+
+slew_penalty_scale: 800
+
+
+
+nominal_conditions:
+
+    # Moon below the horizon
+
+    seeing: 1.1 arcsec
+
+    airmass: 1.0
+
+    transparency: 1.0
+
+    EBV: 0.0
+
+
+
+# Reobserve tiles that have not reached this fraction of their target SNR**2.
+
+min_snr2_fraction: 0.85
+
+
+
+# Merge dark and gray programs.
+
+tiles_nogray: True
+
+
+
+# List of bodies to avoid when scheduling tiles.
+
+avoid_bodies:
+
+    moon: 50 deg
+
+    venus: 2 deg
+
+    mars: 2 deg
+
+    jupiter: 2 deg
+
+    saturn: 2 deg
+
+#    neptune: 2 deg
+
+#    uranus: 2 deg
+
+
+
+#-------------------------------------------------------------------
+
+# Parameters used to schedule fiber assignment.
+
+#-------------------------------------------------------------------
+
+
+
+# Specify the cadence for updating fiber assignments. The choices are:
+
+# - monthly: perform updates at every full moon break.
+
+# - daily: perform updates as part of every afternoon plan.
+
+fiber_assignment_cadence: daily
+
+
+
+# number of fiber_assignement_cadence units to wait before a tile
+
+# goes from observation until adjacent overlapping tiles may be observed
+
+# -1 if overlapping tiles may immediately be observed
+
+# default to -1 for any passes not listed.
+
+# 0 if overlapping tiles should not be observed on same night, but may
+
+# be observed on following day, without waiting for a full fiberassign interval
+
+# 1 if you have to wait a full interval.
+
+fiber_assignment_delay:
+
+    DARK: 0
+
+    BRIGHT: 0
+
+    BACKUP: 0
+
+
+
+# Nominal tile radius for determining whether two tiles overlap.
+
+tile_radius: 1.62 deg
+
+
+
+#-------------------------------------------------------------------
+
+# Parameters to locate files needed by desisurvey.
+
+#-------------------------------------------------------------------
+
+
+
+# Name of file defining DESI tiles for desimodel.io.load_tiles(tiles_file).
+
+# Without path this will look in $DESIMODEL/data/footprint/; otherwise with
+
+# a path (relative or absolute) it will read that file.
+
+# Non-standard tiles files are supported with the following caveats:
+
+# - The program names (DARK,GRAY,BRIGHT,BACKUP) are predefined but not all
+
+#   programs need to be included in the tiles file.
+
+# - Pass numbers are arbitrary integers and do not need to be consecutive
+
+#   or dense. However use of non-standard values will generally require
+
+#   an update to fiber_assignment_order, above.
+
+tiles_file: tiles-main.ecsv
+
+
+
+# trigger treating gray and dark time together
+
+tiles_nogray: True
+
+tiles_trim: False
+
+tiles_lowpass: False
+
+select_program_by_speed: True
+
+
+
+# Base path to pre-pended to all non-absolute paths used for reading and
+
+# writing files managed by this package. The pattern {...} will be expanded
+
+# using environment variables.
+
+output_path: '{DESISURVEY_OUTPUT}'
+
+
+
+rules_file: rules-main.yaml
+
+
+
+fiber_assign_dir: /data/tiles/SVN_tiles
+
+
+
+spectra_dir: /data/dts/exposures/raw


### PR DESCRIPTION
This PR adds a single script to produce the monthly status plot presented to tech board.

The nominal main survey configuration file is included in the `data` directory.

For example usage, see `make_monthly_plot -h`.