### PR TITLE
Calibration tiles design

### DIFF
--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import os
+from astropy.table import Table
+import numpy as np
 from fiberassign.utils import Logger
 from desisurveyops.fba_tertiary_design_io import get_fn
 from desisurveyops.fba_calibration_design_io import (
@@ -69,7 +71,49 @@ def create_tiles(program, field_ra, field_dec, tileid_start, tileid_end, outfn):
 
 
 def create_priorities(program, outfn):
-    d = get_main_primary_priorities(program)
+
+    # AR get the tertiary properties of the DESI Main primary targets
+    # AR note: STD_BRIGHT,STD_FAINT have no priorities
+    # AR       we assign them PRIORITY=3000
+    names, initprios, calib_or_nonstds = get_main_primary_priorities(program)
+    initprios[names == "DESI_STD_BRIGHT"] = 3000
+    initprios[names == "DESI_STD_FAINT"] = 3000
+
+    keys = ["TERTIARY_TARGET", "NUMOBS_DONE_MIN", "NUMOBS_DONE_MAX", "PRIORITY"]
+    # AR we favor re-observations vs. first observations
+    # AR loop on masks
+    myd = {key: [] for key in keys}
+    for name, initprio, calib_or_nonstd in zip(names, initprios, calib_or_nonstds):
+        if initprio is not None:
+            if initprio == 0:
+                myd["TERTIARY_TARGET"].append(name)
+                myd["NUMOBS_DONE_MIN"].append(0)
+                myd["NUMOBS_DONE_MAX"].append(99)
+                myd["PRIORITY"].append(initprio)
+            else:
+                #
+                myd["TERTIARY_TARGET"].append(name)
+                myd["NUMOBS_DONE_MIN"].append(0)
+                myd["NUMOBS_DONE_MAX"].append(0)
+                myd["PRIORITY"].append(initprio)
+                #
+                myd["TERTIARY_TARGET"].append(name)
+                myd["NUMOBS_DONE_MIN"].append(1)
+                myd["NUMOBS_DONE_MAX"].append(98)
+                myd["PRIORITY"].append(5000 + initprio)
+                #
+                myd["TERTIARY_TARGET"].append(name)
+                myd["NUMOBS_DONE_MIN"].append(99)
+                myd["NUMOBS_DONE_MAX"].append(99)
+                myd["PRIORITY"].append(5000 + initprio)
+    # AR create table
+    d = Table()
+    for key in keys:
+        d[key] = myd[key]
+    # AR assert there are no duplicated names
+    d0 = d[d["NUMOBS_DONE_MIN"] == 0]
+    assert len(d0) == np.unique(d0["TERTIARY_TARGET"]).size
+
     d.write(outfn)
 
 

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -70,7 +70,7 @@ def main():
             msg = "{} already exists; exiting".format(outfn)
             log.error(msg)
             raise ValueError(msg)
-        d = get_fba_calibration_tiles(args.prognum, args.targdir)
+        d = get_fba_calibration_tiles(args.prognum)
         d.write(outfn)
 
     if "priorities" in args.steps.split(","):
@@ -82,7 +82,7 @@ def main():
             raise ValueError(msg)
         # AR program
         program, _, _, _, _ = get_calibration_settings(args.prognum)
-        d = get_fba_calibration_priorities(args.prognum, args.targdir, program)
+        d = get_fba_calibration_priorities(args.prognum, program)
         d.write(outfn)
 
     if "targets" in args.steps.split(","):

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -3,6 +3,7 @@
 import os
 from fiberassign.utils import Logger
 from desisurveyops.fba_calibration_design_io import (
+    get_calibration_settings,
     get_fba_calibration_tiles,
     get_fba_calibration_priorities,
     get_fba_calibration_targets,
@@ -79,7 +80,9 @@ def main():
             msg = "{} already exists; exiting".format(outfn)
             log.error(msg)
             raise ValueError(msg)
-        d = get_fba_calibration_priorities(args.prognum, args.targdir)
+        # AR program
+        program, _, _, _, _ = get_calibration_settings(args.prognum)
+        d = get_fba_calibration_priorities(args.prognum, args.targdir, program)
         d.write(outfn)
 
     if "targets" in args.steps.split(","):

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -63,6 +63,9 @@ def main():
 
     args = parse()
 
+    # AR general properties
+    program, field_ra, field_dec, tileid_start, tileid_end = get_calibration_settings(args.prognum)
+
     if "tiles" in args.steps.split(","):
         outfn = os.path.join(args.targdir, "tertiary-tiles-{:04d}.ecsv".format(args.prognum))
         log.info("outfn = {}".format(outfn))
@@ -70,7 +73,7 @@ def main():
             msg = "{} already exists; exiting".format(outfn)
             log.error(msg)
             raise ValueError(msg)
-        d = get_calibration_tiles(args.prognum)
+        d = get_calibration_tiles(program, field_ra, field_dec, tileid_start, tileid_end)
         d.write(outfn)
 
     if "priorities" in args.steps.split(","):
@@ -80,8 +83,6 @@ def main():
             msg = "{} already exists; exiting".format(outfn)
             log.error(msg)
             raise ValueError(msg)
-        # AR program
-        program, _, _, _, _ = get_calibration_settings(args.prognum)
         d = get_calibration_priorities(program)
         d.write(outfn)
 
@@ -92,8 +93,6 @@ def main():
             msg = "{} already exists; exiting".format(outfn)
             log.error(msg)
             raise ValueError(msg)
-        # AR program + field center
-        program, field_ra, field_dec, _, _ = get_calibration_settings(args.prognum)
         d = get_calibration_targets(
             args.prognum,
             program,

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -2,6 +2,7 @@
 
 import os
 from fiberassign.utils import Logger
+from desisurveyops.fba_tertiary_design_io import get_fn
 from desisurveyops.fba_calibration_design_io import (
     get_calibration_settings,
     get_calibration_tiles,
@@ -70,9 +71,7 @@ def main():
     )
 
     if "tiles" in args.steps.split(","):
-        outfn = os.path.join(
-            args.targdir, "tertiary-tiles-{:04d}.ecsv".format(args.prognum)
-        )
+        outfn = get_fn(prognum, "tiles", args.targdir)
         log.info("outfn = {}".format(outfn))
         d = get_calibration_tiles(
             program, field_ra, field_dec, tileid_start, tileid_end
@@ -80,13 +79,13 @@ def main():
         d.write(outfn)
 
     if "priorities" in args.steps.split(","):
-        outfn = get_priofn(argsprognum, targdir=args.targdir)
+        outfn = get_fn(prognum, "priorities", args.targdir)
         log.info("outfn = {}".format(outfn))
         d = get_main_primary_priorities(program)
         d.write(outfn)
 
     if "targets" in args.steps.split(","):
-        outfn = get_targfn(args.prognum, targdir=args.targdir)
+        outfn = get_fn(prognum, "targets", args.targdir)
         log.info("outfn = {}".format(outfn))
         # AR corner case for prognum=8...
         if args.prognum == 8:

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -5,7 +5,7 @@ from fiberassign.utils import Logger
 from desisurveyops.fba_calibration_design_io import (
     get_calibration_settings,
     get_calibration_tiles,
-    get_calibration_priorities,
+    get_main_primary_priorities,
     get_main_primary_targets,
     finalize_calibration_target_table,
 )
@@ -84,7 +84,7 @@ def main():
             msg = "{} already exists; exiting".format(outfn)
             log.error(msg)
             raise ValueError(msg)
-        d = get_calibration_priorities(program)
+        d = get_main_primary_priorities(program)
         d.write(outfn)
 
     if "targets" in args.steps.split(","):

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -94,7 +94,6 @@ def main():
             raise ValueError(msg)
         d = get_calibration_targets(
             args.prognum,
-            args.targdir,
             checker=args.checker,
             radius=args.radius,
             dtver=args.dtver,

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -82,7 +82,7 @@ def main():
             raise ValueError(msg)
         # AR program
         program, _, _, _, _ = get_calibration_settings(args.prognum)
-        d = get_calibration_priorities(args.prognum, program)
+        d = get_calibration_priorities(program)
         d.write(outfn)
 
     if "targets" in args.steps.split(","):

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -10,6 +10,7 @@ from desisurveyops.fba_calibration_design_io import (
     get_calibration_tiles,
     get_main_primary_priorities,
     get_main_primary_targets,
+    get_main_primary_targets_names,
     finalize_calibration_target_table,
 )
 from argparse import ArgumentParser
@@ -129,17 +130,44 @@ def create_targets(prognum, program, field_ra, field_dec, radius, dtver, checker
         do_ignore_gcb = True
     else:
         do_ignore_gcb = False
+
     # AR retrieve main primary targets
     d = get_main_primary_targets(
         program,
         field_ra,
         field_dec,
+        radius=radius,
+        remove_stds=True,
+    )
+
+    # AR get the TERTIARY_TARGET values
+    d["TERTIARY_TARGET"] = get_main_primary_targets_names(
+        d,
+        program,
         tertiary_targets=tertiary_targets,
         initprios=initprios,
-        radius=radius,
         do_ignore_gcb=do_ignore_gcb,
-        dtver=dtver,
     )
+
+    # AR columns we keep
+    keys = ["TERTIARY_TARGET", "RA", "DEC", "PMRA", "PMDEC", "REF_EPOCH", "SUBPRIORITY"]
+
+    # AR rename with ORIG_ prefix some columns to keep the original information
+    # AR    + keep then
+    for key in [
+        "TARGETID",
+        "DESI_TARGET",
+        "BGS_TARGET",
+        "MWS_TARGET",
+        "SCND_TARGET",
+        "PRIORITY_INIT",
+    ]:
+        d[key].name = "ORIG_{}".format(key)
+        keys.append("ORIG_{}".format(key))
+
+    # AR cut on columns
+    d = d[keys]
+
     # AR do all the proper formatting things
     d = finalize_calibration_target_table(
         d,

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -65,9 +65,7 @@ def parse():
 
 
 def create_tiles(program, field_ra, field_dec, tileid_start, tileid_end, outfn):
-    d = get_calibration_tiles(
-        program, field_ra, field_dec, tileid_start, tileid_end
-    )
+    d = get_calibration_tiles(program, field_ra, field_dec, tileid_start, tileid_end)
     d.write(outfn)
 
 
@@ -118,7 +116,9 @@ def create_priorities(program, outfn):
     d.write(outfn)
 
 
-def create_targets(prognum, program, field_ra, field_dec, radius, dtver, checker, priofn, outfn):
+def create_targets(
+    prognum, program, field_ra, field_dec, radius, dtver, checker, priofn, outfn
+):
 
     # AR
     d = Table.read(priofn)
@@ -191,9 +191,7 @@ def main():
     if "tiles" in args.steps.split(","):
         tilesfn = get_fn(args.prognum, "tiles", args.targdir)
         log.info("run create_tiles() to generate {}".format(tilesfn))
-        create_tiles(
-            program, field_ra, field_dec, tileid_start, tileid_end, tilesfn
-        )
+        create_tiles(program, field_ra, field_dec, tileid_start, tileid_end, tilesfn)
 
     if "priorities" in args.steps.split(","):
         priofn = get_fn(args.prognum, "priorities", args.targdir)
@@ -205,7 +203,15 @@ def main():
         targfn = get_fn(args.prognum, "targets", args.targdir)
         log.info("run create_targets() to generate {}".format(targfn))
         create_targets(
-            args.prognum, program, field_ra, field_dec, args.radius, args.dtver, args.checker, priofn, targfn
+            args.prognum,
+            program,
+            field_ra,
+            field_dec,
+            args.radius,
+            args.dtver,
+            args.checker,
+            priofn,
+            targfn,
         )
 
 

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -4,9 +4,9 @@ import os
 from fiberassign.utils import Logger
 from desisurveyops.fba_calibration_design_io import (
     get_calibration_settings,
-    get_fba_calibration_tiles,
-    get_fba_calibration_priorities,
-    get_fba_calibration_targets,
+    get_calibration_tiles,
+    get_calibration_priorities,
+    get_calibration_targets,
 )
 from argparse import ArgumentParser
 
@@ -70,7 +70,7 @@ def main():
             msg = "{} already exists; exiting".format(outfn)
             log.error(msg)
             raise ValueError(msg)
-        d = get_fba_calibration_tiles(args.prognum)
+        d = get_calibration_tiles(args.prognum)
         d.write(outfn)
 
     if "priorities" in args.steps.split(","):
@@ -82,7 +82,7 @@ def main():
             raise ValueError(msg)
         # AR program
         program, _, _, _, _ = get_calibration_settings(args.prognum)
-        d = get_fba_calibration_priorities(args.prognum, program)
+        d = get_calibration_priorities(args.prognum, program)
         d.write(outfn)
 
     if "targets" in args.steps.split(","):
@@ -92,7 +92,7 @@ def main():
             msg = "{} already exists; exiting".format(outfn)
             log.error(msg)
             raise ValueError(msg)
-        d = get_fba_calibration_targets(
+        d = get_calibration_targets(
             args.prognum,
             args.targdir,
             checker=args.checker,

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -61,6 +61,44 @@ def parse():
     return args
 
 
+def create_tiles(program, field_ra, field_dec, tileid_start, tileid_end, outfn):
+    d = get_calibration_tiles(
+        program, field_ra, field_dec, tileid_start, tileid_end
+    )
+    d.write(outfn)
+
+
+def create_priorities(program, outfn):
+    d = get_main_primary_priorities(program)
+    d.write(outfn)
+
+
+def create_targets(prognum, program, field_ra, field_dec, radius, dtver, checker, outfn):
+    # AR corner case for prognum=8...
+    if prognum == 8:
+        do_ignore_gcb = True
+    else:
+        do_ignore_gcb = False
+    # AR retrieve main primary targets
+    d = get_main_primary_targets(
+        program,
+        field_ra,
+        field_dec,
+        radius=radius,
+        do_ignore_gcb=do_ignore_gcb,
+        dtver=dtver,
+    )
+    # AR do all the proper formatting things
+    d = finalize_calibration_target_table(
+        d,
+        prognum,
+        program,
+        checker=checker,
+    )
+    # AR write
+    d.write(outfn)
+
+
 def main():
 
     args = parse()
@@ -71,45 +109,23 @@ def main():
     )
 
     if "tiles" in args.steps.split(","):
-        outfn = get_fn(prognum, "tiles", args.targdir)
-        log.info("outfn = {}".format(outfn))
-        d = get_calibration_tiles(
-            program, field_ra, field_dec, tileid_start, tileid_end
+        tilesfn = get_fn(args.prognum, "tiles", args.targdir)
+        log.info("run create_tiles() to generate {}".format(tilesfn))
+        create_tiles(
+            program, field_ra, field_dec, tileid_start, tileid_end, tilesfn
         )
-        d.write(outfn)
 
     if "priorities" in args.steps.split(","):
-        outfn = get_fn(prognum, "priorities", args.targdir)
-        log.info("outfn = {}".format(outfn))
-        d = get_main_primary_priorities(program)
-        d.write(outfn)
+        priofn = get_fn(args.prognum, "priorities", args.targdir)
+        log.info("run create_priorities() to generate {}".format(priofn))
+        create_priorities(program, priofn)
 
     if "targets" in args.steps.split(","):
-        outfn = get_fn(prognum, "targets", args.targdir)
-        log.info("outfn = {}".format(outfn))
-        # AR corner case for prognum=8...
-        if args.prognum == 8:
-            do_ignore_gcb = True
-        else:
-            do_ignore_gcb = False
-        # AR retrieve main primary targets
-        d = get_main_primary_targets(
-            program,
-            field_ra,
-            field_dec,
-            radius=args.radius,
-            do_ignore_gcb=do_ignore_gcb,
-            dtver=args.dtver,
+        targfn = get_fn(args.prognum, "targets", args.targdir)
+        log.info("run create_targets() to generate {}".format(targfn))
+        create_targets(
+            args.prognum, program, field_ra, field_dec, args.radius, args.dtver, args.checker, targfn
         )
-        # AR do all the proper formatting things
-        d = finalize_calibration_target_table(
-            d,
-            args.prognum,
-            program,
-            checker=args.checker,
-        )
-        # AR write
-        d.write(outfn)
 
 
 if __name__ == "__main__":

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -104,7 +104,7 @@ def main():
             program,
             field_ra,
             field_dec,
-            args.radius,
+            radius=args.radius,
             do_ignore_gcb=do_ignore_gcb,
             dtver=args.dtver,
         )

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+
+import os
+from fiberassign.utils import Logger
+from desisurveyops.fba_calibration_design_io import (
+    fba_calibration_tiles,
+    fba_calibration_priorities,
+    fba_calibration_targets,
+)
+from argparse import ArgumentParser
+
+# AR https://desi.lbl.gov/trac/wiki/SurveyOps/CalibrationFields
+
+log = Logger.get()
+
+valid_steps = ["tiles", "priorities", "targets"]
+
+
+def parse():
+    parser = ArgumentParser(
+        description="Creates {targdir}/tertiary-tiles-{prognumpad}.ecsv, {targdir}/tertiary-priorities-{prognumpad}.ecsv, {targdir}/tertiary-targets-{prognumpad}.fits"
+    )
+    parser.add_argument("--prognum", help="tertiary PROGNUM", type=int)
+    parser.add_argument(
+        "--targdir",
+        help="output folder; for an official design, it should be $DESI_ROOT/fiberassign/special/tertiary/{prognumpad} (default=None)",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--steps",
+        help="comma-separated values (e.g., tiles,priorities,targets)",
+        type=str,
+    )
+    parser.add_argument("--checker", help="checker column (e.g., AR)", type=str)
+    parser.add_argument(
+        "--radius",
+        help="we select targets up that distance (in degree) from the field center (default=3)",
+        type=float,
+        default=3,
+    )
+    parser.add_argument(
+        "--dtver",
+        help="desitarget catalog version (default=1.1.1)",
+        type=str,
+        default="1.1.1",
+    )
+    args = parser.parse_args()
+    # AR valid steps
+    for step in args.steps.split(","):
+        if step not in valid_steps:
+            msg = "non-valid step = {}; exiting".format(step)
+            log.error(msg)
+            raise ValueError(msg)
+    # AR print arguments
+    for kwargs in args._get_kwargs():
+        log.info("{} = {}".format(kwargs[0], kwargs[1]))
+    return args
+
+
+def main():
+
+    args = parse()
+
+    if "tiles" in args.steps.split(","):
+        fba_calibration_tiles(args.prognum, args.targdir)
+
+    if "priorities" in args.steps.split(","):
+        fba_calibration_priorities(args.prognum, args.targdir)
+
+    if "targets" in args.steps.split(","):
+        fba_calibration_targets(
+            args.prognum,
+            args.targdir,
+            checker=args.checker,
+            radius=args.radius,
+            dtver=args.dtver,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -65,12 +65,18 @@ def main():
     args = parse()
 
     # AR general properties
-    program, field_ra, field_dec, tileid_start, tileid_end = get_calibration_settings(args.prognum)
+    program, field_ra, field_dec, tileid_start, tileid_end = get_calibration_settings(
+        args.prognum
+    )
 
     if "tiles" in args.steps.split(","):
-        outfn = os.path.join(args.targdir, "tertiary-tiles-{:04d}.ecsv".format(args.prognum))
+        outfn = os.path.join(
+            args.targdir, "tertiary-tiles-{:04d}.ecsv".format(args.prognum)
+        )
         log.info("outfn = {}".format(outfn))
-        d = get_calibration_tiles(program, field_ra, field_dec, tileid_start, tileid_end)
+        d = get_calibration_tiles(
+            program, field_ra, field_dec, tileid_start, tileid_end
+        )
         d.write(outfn)
 
     if "priorities" in args.steps.split(","):

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -94,13 +94,18 @@ def main():
             msg = "{} already exists; exiting".format(outfn)
             log.error(msg)
             raise ValueError(msg)
+        # AR corner case for prognum=8...
+        if args.prognum == 8:
+            do_ignore_gcb = True
+        else:
+            do_ignore_gcb = False
         # AR retrieve main primary targets
         d = get_main_primary_targets(
-            args.prognum,
             program,
             field_ra,
             field_dec,
             args.radius,
+            do_ignore_gcb=do_ignore_gcb,
             dtver=args.dtver,
         )
         # AR do all the proper formatting things

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -3,9 +3,9 @@
 import os
 from fiberassign.utils import Logger
 from desisurveyops.fba_calibration_design_io import (
-    fba_calibration_tiles,
-    fba_calibration_priorities,
-    fba_calibration_targets,
+    get_fba_calibration_tiles,
+    get_fba_calibration_priorities,
+    get_fba_calibration_targets,
 )
 from argparse import ArgumentParser
 
@@ -63,19 +63,40 @@ def main():
     args = parse()
 
     if "tiles" in args.steps.split(","):
-        fba_calibration_tiles(args.prognum, args.targdir)
+        outfn = os.path.join(args.targdir, "tertiary-tiles-{:04d}.ecsv".format(args.prognum))
+        log.info("outfn = {}".format(outfn))
+        if os.path.isfile(outfn):
+            msg = "{} already exists; exiting".format(outfn)
+            log.error(msg)
+            raise ValueError(msg)
+        d = get_fba_calibration_tiles(args.prognum, args.targdir)
+        d.write(outfn)
 
     if "priorities" in args.steps.split(","):
-        fba_calibration_priorities(args.prognum, args.targdir)
+        outfn = get_priofn(argsprognum, targdir=args.targdir)
+        log.info("outfn = {}".format(outfn))
+        if os.path.isfile(outfn):
+            msg = "{} already exists; exiting".format(outfn)
+            log.error(msg)
+            raise ValueError(msg)
+        d = get_fba_calibration_priorities(args.prognum, args.targdir)
+        d.write(outfn)
 
     if "targets" in args.steps.split(","):
-        fba_calibration_targets(
+        outfn = get_targfn(args.prognum, targdir=args.targdir)
+        log.info("outfn = {}".format(outfn))
+        if os.path.isfile(outfn):
+            msg = "{} already exists; exiting".format(outfn)
+            log.error(msg)
+            raise ValueError(msg)
+        d = get_fba_calibration_targets(
             args.prognum,
             args.targdir,
             checker=args.checker,
             radius=args.radius,
             dtver=args.dtver,
         )
+        d.write(outfn)
 
 
 if __name__ == "__main__":

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -117,7 +117,13 @@ def create_priorities(program, outfn):
     d.write(outfn)
 
 
-def create_targets(prognum, program, field_ra, field_dec, radius, dtver, checker, outfn):
+def create_targets(prognum, program, field_ra, field_dec, radius, dtver, checker, priofn, outfn):
+
+    # AR
+    d = Table.read(priofn)
+    sel = d["NUMOBS_DONE_MIN"] == 0
+    tertiary_targets, initprios = d["TERTIARY_TARGET"][sel], d["PRIORITY"][sel]
+
     # AR corner case for prognum=8...
     if prognum == 8:
         do_ignore_gcb = True
@@ -128,6 +134,8 @@ def create_targets(prognum, program, field_ra, field_dec, radius, dtver, checker
         program,
         field_ra,
         field_dec,
+        tertiary_targets=tertiary_targets,
+        initprios=initprios,
         radius=radius,
         do_ignore_gcb=do_ignore_gcb,
         dtver=dtver,
@@ -165,10 +173,11 @@ def main():
         create_priorities(program, priofn)
 
     if "targets" in args.steps.split(","):
+        priofn = get_fn(args.prognum, "priorities", args.targdir)
         targfn = get_fn(args.prognum, "targets", args.targdir)
         log.info("run create_targets() to generate {}".format(targfn))
         create_targets(
-            args.prognum, program, field_ra, field_dec, args.radius, args.dtver, args.checker, targfn
+            args.prognum, program, field_ra, field_dec, args.radius, args.dtver, args.checker, priofn, targfn
         )
 
 

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -70,30 +70,18 @@ def main():
     if "tiles" in args.steps.split(","):
         outfn = os.path.join(args.targdir, "tertiary-tiles-{:04d}.ecsv".format(args.prognum))
         log.info("outfn = {}".format(outfn))
-        if os.path.isfile(outfn):
-            msg = "{} already exists; exiting".format(outfn)
-            log.error(msg)
-            raise ValueError(msg)
         d = get_calibration_tiles(program, field_ra, field_dec, tileid_start, tileid_end)
         d.write(outfn)
 
     if "priorities" in args.steps.split(","):
         outfn = get_priofn(argsprognum, targdir=args.targdir)
         log.info("outfn = {}".format(outfn))
-        if os.path.isfile(outfn):
-            msg = "{} already exists; exiting".format(outfn)
-            log.error(msg)
-            raise ValueError(msg)
         d = get_main_primary_priorities(program)
         d.write(outfn)
 
     if "targets" in args.steps.split(","):
         outfn = get_targfn(args.prognum, targdir=args.targdir)
         log.info("outfn = {}".format(outfn))
-        if os.path.isfile(outfn):
-            msg = "{} already exists; exiting".format(outfn)
-            log.error(msg)
-            raise ValueError(msg)
         # AR corner case for prognum=8...
         if args.prognum == 8:
             do_ignore_gcb = True

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -92,10 +92,15 @@ def main():
             msg = "{} already exists; exiting".format(outfn)
             log.error(msg)
             raise ValueError(msg)
+        # AR program + field center
+        program, field_ra, field_dec, _, _ = get_calibration_settings(args.prognum)
         d = get_calibration_targets(
             args.prognum,
+            program,
+            field_ra,
+            field_dec,
+            args.radius,
             checker=args.checker,
-            radius=args.radius,
             dtver=args.dtver,
         )
         d.write(outfn)

--- a/bin/desi_fba_calibration_inputs
+++ b/bin/desi_fba_calibration_inputs
@@ -6,7 +6,8 @@ from desisurveyops.fba_calibration_design_io import (
     get_calibration_settings,
     get_calibration_tiles,
     get_calibration_priorities,
-    get_calibration_targets,
+    get_main_primary_targets,
+    finalize_calibration_target_table,
 )
 from argparse import ArgumentParser
 
@@ -93,15 +94,23 @@ def main():
             msg = "{} already exists; exiting".format(outfn)
             log.error(msg)
             raise ValueError(msg)
-        d = get_calibration_targets(
+        # AR retrieve main primary targets
+        d = get_main_primary_targets(
             args.prognum,
             program,
             field_ra,
             field_dec,
             args.radius,
-            checker=args.checker,
             dtver=args.dtver,
         )
+        # AR do all the proper formatting things
+        d = finalize_calibration_target_table(
+            d,
+            args.prognum,
+            program,
+            checker=args.checker,
+        )
+        # AR write
         d.write(outfn)
 
 

--- a/bin/desi_fba_tertiary_wrapper
+++ b/bin/desi_fba_tertiary_wrapper
@@ -42,6 +42,11 @@ def parse():
         default=None,
     )
     parser.add_argument(
+        "--forcetileid",
+        help="run fba_launch with the --forcetiled option; use with caution!",
+        action="store_true",
+    )
+    parser.add_argument(
         "--dry_run",
         help="do not execute any command, just print on the prompt",
         action="store_true",
@@ -141,6 +146,11 @@ def main():
         if args.add_main_too:
             maintoofn = os.path.join(os.getenv("DESI_SURVEYOPS"), "mtl", "main", "ToO", "ToO.ecsv")
             cmd = "{},{}".format(cmd, maintoofn)
+        # AR force tileid?
+        # AR    ! use with caution !
+        # AR    (for cases where tiles are re-designed after having been svn-committed)
+        if args.forcetileid:
+            cmd = "{} --forcetileid y".format(cmd)
         log.info(cmd)
         if not args.dry_run:
             os.system(cmd)

--- a/bin/desi_fba_tertiary_wrapper
+++ b/bin/desi_fba_tertiary_wrapper
@@ -33,6 +33,7 @@ def parse():
     )
     parser.add_argument(
         "--add_main_too",
+        help="add targets from the $DESI_SURVEYOPS/mtl/main/ToO/ToO.ecsv file",
         action="store_true",
     )
     parser.add_argument(

--- a/bin/desi_fba_tertiary_wrapper
+++ b/bin/desi_fba_tertiary_wrapper
@@ -32,6 +32,10 @@ def parse():
         default=None,
     )
     parser.add_argument(
+        "--add_main_too",
+        action="store_true",
+    )
+    parser.add_argument(
         "--dry_run",
         help="do not execute any command, just print on the prompt",
         action="store_true",
@@ -124,6 +128,9 @@ def main():
         cmd = "{} --goaltype {} --hdr_survey {} --hdr_faprgrm {}".format(cmd, obsconds, hdr_survey, hdr_faprgrm)
         # AR ToO file
         cmd = "{} --too_tile --custom_too_file {}".format(cmd, toofn)
+        if args.add_main_too:
+            maintoofn = os.path.join(os.getenv("DESI_SURVEYOPS"), "mtl", "main", "ToO", "ToO.ecsv")
+            cmd = "{},{}".format(cmd, maintoofn)
         log.info(cmd)
         if not args.dry_run:
             os.system(cmd)

--- a/bin/desi_fba_tertiary_wrapper
+++ b/bin/desi_fba_tertiary_wrapper
@@ -36,6 +36,12 @@ def parse():
         action="store_true",
     )
     parser.add_argument(
+        "--only_tileid",
+        help="run for only a single tile (mode used for the calibration tiles; verify beforehand that previous tileids have already been designed!",
+        type=int,
+        default=None,
+    )
+    parser.add_argument(
         "--dry_run",
         help="do not execute any command, just print on the prompt",
         action="store_true",
@@ -82,7 +88,11 @@ def main():
     ntile = len(tiles)
 
     # AR loop on tiles
-    for i in range(ntile):
+    if args.only_tileid:
+        ii = [np.where(tiles["TILEID"] == args.only_tileid)[0][0]]
+    else:
+        ii = np.arange(ntile, dtype=int)
+    for i in ii:
 
         # AR tile properties
         tileid = tiles["TILEID"][i]

--- a/bin/desi_fba_tertiary_wrapper
+++ b/bin/desi_fba_tertiary_wrapper
@@ -48,6 +48,12 @@ def parse():
         action="store_true",
     )
     parser.add_argument(
+        "--custom_too_development",
+        help="is this for development? (allows args.custom_too_file to be outside of $DESI_SURVEYOPS)",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
         "--dry_run",
         help="do not execute any command, just print on the prompt",
         action="store_true",
@@ -153,6 +159,10 @@ def main():
         if args.forcetileid:
             cmd = "{} --forcetileid y".format(cmd)
         log.info(cmd)
+        # AR custom_too_development?
+        # AR    use for testing the design
+        if args.custom_too_development:
+            cmd = "{} --custom_too_development".format(cmd)
         if not args.dry_run:
             os.system(cmd)
 

--- a/doc/fba_calibration_readme.txt
+++ b/doc/fba_calibration_readme.txt
@@ -1,0 +1,107 @@
+# pick a prognum and a TILEID
+PROGNUM=5
+TILEID=83000  # the tileid to design; for calibration, we design them one-by-one
+CHECKER=AR    # checker name for the ToO*ecsv CHECKER column; your initials
+
+
+# ====================================================
+# environment + various settings
+
+PROGNUMPAD=`echo $PROGNUM | awk '{printf("%04d\n", $1)}'`
+TILEIDPAD=`echo $TILEID | awk '{printf("%06d\n", $1)}'`
+
+# load the environment and set variables
+source /global/cfs/cdirs/desi/software/desi_environment.sh 22.2
+module load desisurveyops
+module swap fiberassign/5.7.0
+export DESIMODEL=/global/common/software/desi/$NERSC_HOST/desiconda/current/code/desimodel/main
+export SKYHEALPIXS_DIR=$DESI_ROOT/target/skyhealpixs/v1
+
+# pick the latest rundate
+#   (as we design the tiles one-by-one, months/years apart)
+FPSTATEFN=`ls $DESIMODEL/data/focalplane/desi-state_*ecsv | tail -n 1`
+RUNDATE=`tail -n 1 $FPSTATEFN | awk '{print $1}'`
+echo "RUNDATE = $RUNDATE"
+
+# desitarget catalogs version ! for standards only !
+# calibration tiles are either BRIGHT or DARK, so use 1.1.1
+STD_DTVER=1.1.1
+
+# go to the official folder for fiberassign design
+# (if designing the first tile for PROGNUM, create this folder beforehand)
+# (if you want to run a test, just point TERTIARY_DESIGN_DIR to your test folder;
+#   note that you will probably need to copy there some files)
+TERTIARY_DESIGN_DIR=$DESI_ROOT/survey/fiberassign/special/tertiary/$PROGNUMPAD
+# ====================================================
+
+
+# ====================================================
+# if designing the first tile for PROGNUM:
+
+# first generate tiles/priorities/targets
+desi_fba_calibration_inputs --prognum $PROGNUM --targdir $TERTIARY_DESIGN_DIR --steps tiles,priorities,targets --checker $CHECKER
+
+# verify that the three files have been created
+ls -lrth $TERTIARY_DESIGN_DIR/tertiary-{tiles,priorities,targets}-$PROGNUMPAD.*
+# ====================================================
+
+
+
+# ====================================================
+# then create for TILEID:
+# - the ToO-$PROGNUM-$TILEID.{ecsv,log} files
+# - the fiberassign-$TILEIDPAD.{fits.gz,png,log} files
+# - if the tile has already been designed+svn-committed, add --forcetileid to the desi_fba_tertiary_wrapper call
+#   ! use with caution !
+# - if you want to run a test in a test TERTIARY_DESIGN_DIR folder, add --custom_too_development
+#   to the desi_fba_tertiary_wrapper call)
+# - because of being too cautious in fiberassign/5.7.0, ToO files from outside $DESI_SURVEYOPS/
+#       are not accepted; hence we need to run with --custom_too_development anyway...
+FADIR=$DESI_TARGET/fiberassign/tiles/trunk # folder to parse for previous tileids
+desi_fba_tertiary_wrapper --prognum $PROGNUM --targdir $TERTIARY_DESIGN_DIR --rundate $RUNDATE --std_dtver $STD_DTVER --add_main_too --only_tileid $TILEID --custom_too_development
+
+# verify that the files have been created
+ls -tlrh $TERTIARY_DESIGN_DIR/ToO-$PROGNUM-$TILEID.{ecsv,log}
+ls -tlrh $TERTIARY_DESIGN_DIR/${TILEIDPAD:0:3}/fiberassign-$TILEIDPAD.{fits.gz,png,log}
+# ====================================================
+
+
+
+# ====================================================
+# now svn-commit
+#
+# first update your local checkouts
+#
+# set path to your up-to-date checkout of surveyops
+# note that you just need to checkout the tertiary folder (the mtl folder is large!)
+# export MYSURVEYOPS=your_surveyops_checkout
+# if you do not have a checkout, run this from $MYSURVEYOPS:
+#   svn --username your_wiki_username co https://desi.lbl.gov/trac/browser/data/surveyops/trunk/tertiary
+cd $MYSURVEYOPS/tertiary
+svn up
+
+# if designing the first tile for PROGNUM:
+cd $MYSURVEYOPS
+mkdir tertiary/$PROGNUMPAD                                                                                                                                                  
+cp -p $TERTIARY_DESIGN_DIR/tertiary-{tiles,priorities,targets}-$PROGNUMPAD.* tertiary/$PROGNUMPAD/
+svn add tertiary/$PROGNUMPAD
+svn commit tertiary/$PROGNUMPAD -m "Adding tertiary$PROGNUM tiles, priorities, targets files"
+
+# svn-commit the TILEID ToO files
+cd $MYSURVEYOPS
+cp -p $TERTIARY_DESIGN_DIR/ToO-$PROGNUM-$TILEID.{ecsv,log} tertiary/$PROGNUMPAD/
+svn add tertiary/$PROGNUMPAD/ToO-$PROGNUMPAD-$TILEIDPAD.*
+svn commit tertiary/$PROGNUMPAD -m "Adding ToO-$PROGNUMPAD-$TILEIDPAD ecsv and log"
+
+# set path to your up-to-date-checkout of tiles
+# note that you just need to checkout the 083/ folder (the rest is large!)
+# export MYTILES=your_tiles_checkout
+# if you do not have a checkout, run this from $MYTILES:
+#   svn --username your_wiki_username co https://desi.lbl.gov/trac/browser/data/tiles/trunk/083
+cd $MYTILES/${TILEIDPAD:0:3}
+svn up
+cp -p $TERTIARY_DESIGN_DIR/${TILEIDPAD:0:3}/fiberassign-$TILEIDPAD.{fits.gz,png,log} .
+svn add fiberassign-$TILEIDPAD.{fits.gz,png,log}
+svn commit fiberassign-$TILEIDPAD.{fits.gz,png,log} -m "add calibration tile ($TILEID from tertiary$PROGNUM)"
+# ====================================================
+

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -5,10 +5,7 @@ from glob import glob
 import numpy as np
 import fitsio
 from astropy.table import Table
-from astropy.coordinates import SkyCoord
-from astropy import units as u
 import healpy as hp
-from desisurvey.tileqa import lb2uv
 from desimodel.focalplane.geometry import get_tile_radius_deg
 from desimodel.footprint import tiles2pix, is_point_in_desi
 from desitarget.io import read_targets_in_hp

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -137,7 +137,7 @@ def get_calibration_tiles(
     return d
 
 
-def get_calibration_priorities(program):
+def get_main_primary_priorities(program):
 
     # AR keys
     keys = ["TERTIARY_TARGET", "NUMOBS_DONE_MIN", "NUMOBS_DONE_MAX", "PRIORITY"]
@@ -219,7 +219,7 @@ def get_main_primary_targets(
     if priofn is not None:
         prios = Table.read(priofn)
     else:
-        prios = get_calibration_priorities(program)
+        prios = get_main_primary_priorities(program)
     # AR cutting on NUMOBS_DONE_MIN=0
     prios = prios[prios["NUMOBS_DONE_MIN"] == 0]
 

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -201,19 +201,22 @@ def get_calibration_priorities(program):
 def get_calibration_targets(
     prognum,
     targdir,
+    priofn=None,
     checker="AR",
     radius=3,
     dtver="1.1.1",
 ):
 
-    # AR tertiary priorities
-    fn = get_priofn(prognum, targdir=targdir)
-    prios = Table.read(fn)
-    # AR cutting on NUMOBS_DONE_MIN=0
-    prios = prios[prios["NUMOBS_DONE_MIN"] == 0]
-
     # AR program + field center
     program, field_ra, field_dec, _, _ = get_calibration_settings(prognum)
+
+    # AR tertiary priorities
+    if priofn is not None:
+        prios = Table.read(priofn)
+    else:
+        prios = get_calibration_priorities(program)
+    # AR cutting on NUMOBS_DONE_MIN=0
+    prios = prios[prios["NUMOBS_DONE_MIN"] == 0]
 
     # AR desitarget targets
     hpdir = os.path.join(

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -413,7 +413,7 @@ def get_main_primary_targets(
         msg = "the set PRIORITY_INIT differs from the desitarget one for {}/{} rows; please check!".format(
             sel.sum(), len(d)
         )
-        log.warning(ms)
+        log.warning(msg)
 
     # AR other columns
     for key in ["RA", "DEC", "PMRA", "PMDEC", "REF_EPOCH", "SUBPRIORITY"]:

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -201,11 +201,11 @@ def get_calibration_priorities(program):
 
 
 def get_main_primary_targets(
-    prognum,
     program,
     field_ra,
     field_dec,
     radius,
+    do_ignore_gcb=False,
     priofn=None,
     dtver="1.1.1",
 ):
@@ -298,7 +298,7 @@ def get_main_primary_targets(
         )
     )
     ignore = (ignore_std) | (ignore_wd)
-    if prognum == 8:
+    if do_ignore_gcb:
         ignore_gcb = (targ["SCND_TARGET"] & scnd_mask["GC_BRIGHT"]) > 0
         log.info("priority check: ignoring {} GC_BRIGHT".format(ignore_gcb.sum()))
         ignore |= ignore_gcb

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -100,7 +100,7 @@ def get_calibration_settings(prognum):
 
 
 # AR
-def get_tile_centers(field_ra, field_dec, ntile):
+def get_calibration_tile_centers(field_ra, field_dec, ntile):
     # AR offsets in degrees
     offset_ras = np.array([0, 0.048, 0, -0.048, 0, 0, 1.000, 0, 0])
     offset_decs = np.array([0, 0, 1.000, 0, -1.000, 0.048, 0, -0.048, -1.000])
@@ -128,7 +128,7 @@ def get_calibration_tiles(
     )
 
     # AR no ra wrapping needed for the calibration field centers
-    tileras, tiledecs = get_tile_centers(field_ra, field_dec, ntile)
+    tileras, tiledecs = get_calibration_tile_centers(field_ra, field_dec, ntile)
 
     # AR create + write table
     d = create_tiles_table(tileids, tileras, tiledecs, program)

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -402,7 +402,7 @@ def get_main_primary_targets_names(
     # AR except for (6) GC_BRIGHT in COSMOS/BRIGHT (same reason as above)
     myprios = -99 + np.zeros(len(targ))
     for t, p in zip(tertiary_targets, initprios):
-        myprios[names == t] = p
+        myprios[names.astype(str) == t] = p
     ignore_std = np.in1d(names.astype(str), ["DESI_STD_BRIGHT", "DESI_STD_FAINT"])
     log.info(
         "priority_check: ignoring {} DESI_STD_BRIGHT|DESI_STD_FAINT".format(

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -111,7 +111,7 @@ def get_tile_centers(field_ra, field_dec, ntile):
     return ras, decs
 
 
-def get_fba_calibration_tiles(prognum):
+def get_calibration_tiles(prognum):
 
     # AR tiles list settings
     program, field_ra, field_dec, tileid_start, tileid_end = get_calibration_settings(
@@ -134,7 +134,7 @@ def get_fba_calibration_tiles(prognum):
     return d
 
 
-def get_fba_calibration_priorities(prognum, program):
+def get_calibration_priorities(prognum, program):
 
     # AR keys
     keys = ["TERTIARY_TARGET", "NUMOBS_DONE_MIN", "NUMOBS_DONE_MAX", "PRIORITY"]
@@ -198,7 +198,7 @@ def get_fba_calibration_priorities(prognum, program):
     return d
 
 
-def get_fba_calibration_targets(
+def get_calibration_targets(
     prognum,
     targdir,
     checker="AR",

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -168,10 +168,7 @@ def get_fba_calibration_tiles(prognum, targdir):
     return d
 
 
-def get_fba_calibration_priorities(prognum, targdir):
-
-    # AR program
-    program, _, _, _, _ = get_calibration_settings(prognum)
+def get_fba_calibration_priorities(prognum, targdir, program):
 
     # AR keys
     keys = ["TERTIARY_TARGET", "NUMOBS_DONE_MIN", "NUMOBS_DONE_MAX", "PRIORITY"]

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -138,15 +138,7 @@ def get_ebv_meds(tiles):
     return ebv_meds
 
 
-def fba_calibration_tiles(prognum, targdir):
-
-    # AR output file
-    outfn = os.path.join(targdir, "tertiary-tiles-{:04d}.ecsv".format(prognum))
-    log.info("outfn = {}".format(outfn))
-    if os.path.isfile(outfn):
-        msg = "{} already exists; exiting".format(outfn)
-        log.error(msg)
-        raise ValueError(msg)
+def get_fba_calibration_tiles(prognum, targdir):
 
     # AR tiles list settings
     program, field_ra, field_dec, tileid_start, tileid_end = get_calibration_settings(
@@ -172,18 +164,11 @@ def fba_calibration_tiles(prognum, targdir):
     d["IN_DESI"] = True
     d["EBV_MED"] = get_ebv_meds(d).round(3)
     d["DESIGNHA"] = 0
-    d.write(outfn)
+
+    return d
 
 
-def fba_calibration_priorities(prognum, targdir):
-
-    # AR output file
-    outfn = get_priofn(prognum, targdir=targdir)
-    log.info("outfn = {}".format(outfn))
-    if os.path.isfile(outfn):
-        msg = "{} already exists; exiting".format(outfn)
-        log.error(msg)
-        raise ValueError(msg)
+def get_fba_calibration_priorities(prognum, targdir):
 
     # AR program
     program, _, _, _, _ = get_calibration_settings(prognum)
@@ -247,25 +232,16 @@ def fba_calibration_priorities(prognum, targdir):
     d0 = d[d["NUMOBS_DONE_MIN"] == 0]
     assert len(d0) == np.unique(d0["TERTIARY_TARGET"]).size
 
-    # AR write table
-    d.write(outfn)
+    return d
 
 
-def fba_calibration_targets(
+def get_fba_calibration_targets(
     prognum,
     targdir,
     checker="AR",
     radius=3,
     dtver="1.1.1",
 ):
-
-    # AR output file
-    outfn = get_targfn(prognum, targdir=targdir)
-    log.info("outfn = {}".format(outfn))
-    if os.path.isfile(outfn):
-        msg = "{} already exists; exiting".format(outfn)
-        log.error(msg)
-        raise ValueError(msg)
 
     # AR tertiary priorities
     fn = get_priofn(prognum, targdir=targdir)
@@ -395,4 +371,4 @@ def fba_calibration_targets(
     ]:
         d["ORIG_{}".format(key)] = targ[key]
 
-    d.write(outfn)
+    return d

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -138,7 +138,7 @@ def get_ebv_meds(tiles):
     return ebv_meds
 
 
-def get_fba_calibration_tiles(prognum, targdir):
+def get_fba_calibration_tiles(prognum):
 
     # AR tiles list settings
     program, field_ra, field_dec, tileid_start, tileid_end = get_calibration_settings(
@@ -168,7 +168,7 @@ def get_fba_calibration_tiles(prognum, targdir):
     return d
 
 
-def get_fba_calibration_priorities(prognum, targdir, program):
+def get_fba_calibration_priorities(prognum, program):
 
     # AR keys
     keys = ["TERTIARY_TARGET", "NUMOBS_DONE_MIN", "NUMOBS_DONE_MAX", "PRIORITY"]

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -303,7 +303,15 @@ def get_main_primary_targets(
         log.info("priority check: ignoring {} GC_BRIGHT".format(ignore_gcb.sum()))
         ignore |= ignore_gcb
     sel = (myprios != targ["PRIORITY_INIT"]) & (~ignore)
-    assert sel.sum() == 0
+
+    # AR sanity check
+    # AR do not raise an error, as according to the usage it could be ok
+    # AR    (because this as been tested only on calibration fields)
+    if sel.sum() > 0:
+        msg = "the set PRIORITY_INIT differs from the desitarget one for {}/{} rows; please check!".format(
+            sel.sum(), len(d)
+        )
+        log.warning(ms)
 
     # AR other columns
     for key in ["RA", "DEC", "PMRA", "PMDEC", "REF_EPOCH", "SUBPRIORITY"]:

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -9,6 +9,7 @@ from astropy.coordinates import SkyCoord
 from astropy import units as u
 import healpy as hp
 from desisurvey.tileqa import lb2uv
+from desimodel.focalplane.geometry import get_tile_radius_deg
 from desimodel.footprint import tiles2pix, is_point_in_desi
 from desitarget.io import read_targets_in_hp
 from desitarget.targets import encode_targetid
@@ -207,11 +208,15 @@ def get_main_primary_targets(
     program,
     field_ras,
     field_decs,
-    radius,
+    radius=None,
     do_ignore_gcb=False,
     priofn=None,
     dtver="1.1.1",
 ):
+
+    # AR default to desi tile radius
+    if radius is None:
+        radius = get_tile_radius_deg()
 
     # AR tertiary priorities
     if priofn is not None:

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python
+
+import os
+import numpy as np
+from astropy.table import Table
+from astropy.coordinates import SkyCoord
+from astropy import units as u
+import healpy
+from desisurvey.tileqa import lb2uv
+from desitarget.io import read_targets_in_cap
+from desitarget.targets import encode_targetid
+from desitarget.targetmask import desi_mask, bgs_mask, mws_mask, scnd_mask
+from fiberassign.fba_tertiary_io import get_priofn, get_targfn
+from fiberassign.utils import Logger
+
+# AR https://desi.lbl.gov/trac/wiki/SurveyOps/CalibrationFields
+
+log = Logger.get()
+
+# AR settings
+def get_calibration_settings(prognum):
+    # AR XMMLSS DARK
+    if prognum == 5:
+        program, field_ra, field_dec, tileid_start, tileid_end = (
+            "DARK",
+            35.7,
+            -4.75,
+            83000,
+            83019,
+        )
+    # AR XMMLSS BRIGHT
+    elif prognum == 6:
+        program, field_ra, field_dec, tileid_start, tileid_end = (
+            "BRIGHT",
+            35.7,
+            -4.75,
+            83020,
+            83039,
+        )
+    # AR COSMOS DARK
+    elif prognum == 7:
+        program, field_ra, field_dec, tileid_start, tileid_end = (
+            "DARK",
+            150.1,
+            2.182,
+            83040,
+            83059,
+        )
+    # AR COSMOS BRIGHT
+    elif prognum == 8:
+        program, field_ra, field_dec, tileid_start, tileid_end = (
+            "BRIGHT",
+            150.1,
+            2.182,
+            83060,
+            83079,
+        )
+    # AR MBHB1 DARK
+    elif prognum == 9:
+        program, field_ra, field_dec, tileid_start, tileid_end = (
+            "DARK",
+            203.5,
+            17.5,
+            83080,
+            83099,
+        )
+    # AR MBHB1 BRIGHT
+    elif prognum == 10:
+        program, field_ra, field_dec, tileid_start, tileid_end = (
+            "BRIGHT",
+            203.5,
+            17.5,
+            83100,
+            83119,
+        )
+    # AR GAMA15 DARK
+    elif prognum == 11:
+        program, field_ra, field_dec, tileid_start, tileid_end = (
+            "DARK",
+            215.7,
+            -0.7,
+            83120,
+            83139,
+        )
+    # AR GAMA15 BRIGHT
+    elif prognum == 12:
+        program, field_ra, field_dec, tileid_start, tileid_end = (
+            "BRIGHT",
+            215.7,
+            -0.7,
+            83140,
+            83159,
+        )
+    else:
+        msg = "prognum = {} not recognized; exiting".format(prognum)
+        log.error(msg)
+        raise ValueError(msg)
+    return program, field_ra, field_dec, tileid_start, tileid_end
+
+
+# AR
+def get_tile_centers(field_ra, field_dec, ntile):
+    # AR offsets in degrees
+    offset_ras = np.array([0, 0.048, 0, -0.048, 0, 0, 1.000, 0, 0])
+    offset_decs = np.array([0, 0, 1.000, 0, -1.000, 0.048, 0, -0.048, -1.000])
+    ras = field_ra + offset_ras / np.cos(np.radians(field_dec))
+    decs = field_dec + offset_decs
+    ras, decs = np.tile(ras, 10000)[:ntile], np.tile(decs, 10000)[:ntile]
+    ras[ras >= 360] -= 360
+    return ras, decs
+
+
+# AR adapted from https://github.com/desihub/desisurvey/blob/94b02bdae04137526bf98dcec0dca8bd29a231d3/py/desisurvey/tileqa.py#L525-L554
+def get_ebv_meds(tiles):
+    nside = 512
+    theta, phi = healpy.pix2ang(nside, np.arange(12 * nside**2))
+    la, ba = phi * 180.0 / np.pi, 90 - theta * 180.0 / np.pi
+    from desiutil import dust
+
+    ebva = dust.ebv(
+        la, ba, frame="galactic", mapdir=os.getenv("DUST_DIR") + "/maps", scaling=1
+    )
+    if isinstance(tiles, Table):
+        ra = tiles["RA"].data
+        dec = tiles["DEC"].data
+    else:
+        ra = tiles["RA"]
+        dec = tiles["DEC"]
+    coord = SkyCoord(ra=ra * u.deg, dec=dec * u.deg, frame="icrs")
+    coordgal = coord.galactic
+    lt, bt = coordgal.l.value, coordgal.b.value
+    uvt = lb2uv(lt, bt)
+    fprad = 1.605
+    ebv_meds = np.zeros(len(tiles))
+    for i in range(len(tiles)):
+        ind = healpy.query_disc(nside, uvt[i], fprad * np.pi / 180.0)
+        ebv_meds[i] = np.median(ebva[ind])
+    return ebv_meds
+
+
+def fba_calibration_tiles(prognum, targdir):
+
+    # AR output file
+    outfn = os.path.join(targdir, "tertiary-tiles-{:04d}.ecsv".format(prognum))
+    log.info("outfn = {}".format(outfn))
+    if os.path.isfile(outfn):
+        msg = "{} already exists; exiting".format(outfn)
+        log.error(msg)
+        raise ValueError(msg)
+
+    # AR tiles list settings
+    program, field_ra, field_dec, tileid_start, tileid_end = get_calibration_settings(
+        prognum
+    )
+    ntile = tileid_end - tileid_start + 1
+    log.info(
+        "will define {} tiles (TILEID={:06d}-{:06d})".format(
+            ntile, tileid_start, tileid_end
+        )
+    )
+
+    # AR no ra wrapping needed for the calibration field centers
+    ras, decs = get_tile_centers(field_ra, field_dec, ntile)
+    # AR round to 3 digits
+    ras, decs = ras.round(3), decs.round(3)
+
+    # AR create + write table
+    d = Table()
+    d["TILEID"] = np.arange(tileid_start, tileid_end + 1, dtype=int)
+    d["RA"], d["DEC"] = ras, decs
+    d["PROGRAM"] = program
+    d["IN_DESI"] = True
+    d["EBV_MED"] = get_ebv_meds(d).round(3)
+    d["DESIGNHA"] = 0
+    d.write(outfn)
+
+
+def fba_calibration_priorities(prognum, targdir):
+
+    # AR output file
+    outfn = get_priofn(prognum, targdir=targdir)
+    log.info("outfn = {}".format(outfn))
+    if os.path.isfile(outfn):
+        msg = "{} already exists; exiting".format(outfn)
+        log.error(msg)
+        raise ValueError(msg)
+
+    # AR program
+    program, _, _, _, _ = get_calibration_settings(prognum)
+
+    # AR keys
+    keys = ["TERTIARY_TARGET", "NUMOBS_DONE_MIN", "NUMOBS_DONE_MAX", "PRIORITY"]
+
+    # AR note: STD_BRIGHT,STD_FAINT have no priorities
+    # AR       we assign them PRIORITY=3000
+    desi_mask["STD_BRIGHT"].priorities["UNOBS"] = 3000
+    desi_mask["STD_FAINT"].priorities["UNOBS"] = 3000
+
+    # AR we discard some names
+    black_names = {}
+    for prefix, mask in zip(
+        ["DESI", "MWS", "BGS", "SCND"],
+        [desi_mask, mws_mask, bgs_mask, scnd_mask],
+    ):
+        black_names[prefix] = [
+            key for key in mask.names() if key[-5:] in ["NORTH", "SOUTH"]
+        ]
+
+    # AR loop on masks
+    myd = {key: [] for key in keys}
+    for prefix, mask in zip(
+        ["DESI", "MWS", "BGS", "SCND"],
+        [desi_mask, mws_mask, bgs_mask, scnd_mask],
+    ):
+        names = [name for name in mask.names() if name not in black_names[prefix]]
+        for name in names:
+            if program in mask[name].obsconditions:
+                if "UNOBS" in mask[name].priorities:
+                    if mask[name].priorities["UNOBS"] == 0:
+                        myd["TERTIARY_TARGET"].append("{}_{}".format(prefix, name))
+                        myd["NUMOBS_DONE_MIN"].append(0)
+                        myd["NUMOBS_DONE_MAX"].append(99)
+                        myd["PRIORITY"].append(mask[name].priorities["UNOBS"])
+                    else:
+                        #
+                        myd["TERTIARY_TARGET"].append("{}_{}".format(prefix, name))
+                        myd["NUMOBS_DONE_MIN"].append(0)
+                        myd["NUMOBS_DONE_MAX"].append(0)
+                        myd["PRIORITY"].append(mask[name].priorities["UNOBS"])
+                        #
+                        myd["TERTIARY_TARGET"].append("{}_{}".format(prefix, name))
+                        myd["NUMOBS_DONE_MIN"].append(1)
+                        myd["NUMOBS_DONE_MAX"].append(98)
+                        myd["PRIORITY"].append(5000 + mask[name].priorities["UNOBS"])
+                        #
+                        myd["TERTIARY_TARGET"].append("{}_{}".format(prefix, name))
+                        myd["NUMOBS_DONE_MIN"].append(99)
+                        myd["NUMOBS_DONE_MAX"].append(99)
+                        myd["PRIORITY"].append(5000 + mask[name].priorities["UNOBS"])
+
+    # AR create table
+    d = Table()
+    for key in keys:
+        d[key] = myd[key]
+
+    # AR assert there are no duplicated names
+    d0 = d[d["NUMOBS_DONE_MIN"] == 0]
+    assert len(d0) == np.unique(d0["TERTIARY_TARGET"]).size
+
+    # AR write table
+    d.write(outfn)
+
+
+def fba_calibration_targets(
+    prognum,
+    targdir,
+    checker="AR",
+    radius=3,
+    dtver="1.1.1",
+):
+
+    # AR output file
+    outfn = get_targfn(prognum, targdir=targdir)
+    log.info("outfn = {}".format(outfn))
+    if os.path.isfile(outfn):
+        msg = "{} already exists; exiting".format(outfn)
+        log.error(msg)
+        raise ValueError(msg)
+
+    # AR tertiary priorities
+    fn = get_priofn(prognum, targdir=targdir)
+    prios = Table.read(fn)
+    # AR cutting on NUMOBS_DONE_MIN=0
+    prios = prios[prios["NUMOBS_DONE_MIN"] == 0]
+
+    # AR program + field center
+    program, field_ra, field_dec, _, _ = get_calibration_settings(prognum)
+
+    # AR desitarget targets
+    hpdir = os.path.join(
+        os.getenv("DESI_TARGET"),
+        "catalogs",
+        "dr9",
+        dtver,
+        "targets",
+        "main",
+        "resolve",
+        program.lower(),
+    )
+    radecrad = [field_ra, field_dec, radius]
+    targ = Table(read_targets_in_cap(hpdir, radecrad, quick=True))
+
+    # AR remove STD_BRIGHT,STD_FAINT
+    # AR    as those will also be included in the fba_launch
+    # AR    call with the --targ_std_only argument
+    names = ["STD_BRIGHT", "STD_FAINT"]
+    reject = np.zeros(len(targ), dtype=bool)
+    for name in names:
+        reject |= (targ["DESI_TARGET"] & desi_mask[name]) > 0
+    print("removing {} names={} targets".format(reject.sum(), ",".join(names)))
+    targ = targ[~reject]
+
+    # AR create table
+    d = Table()
+    # AR header
+    d.meta["EXTNAME"] = "TARGETS"
+    d.meta["FAPRGRM"] = "tertiary{}".format(prognum)
+    d.meta["OBSCONDS"] = program
+    assert program in ["BRIGHT", "DARK"]
+    d.meta["SBPROF"] = "ELG" if program == "DARK" else "BGS"
+    d.meta["GOALTIME"] = 1000.0 if program == "DARK" else 180.0
+    # AR if useful..
+    d.meta["TARG"] = hpdir
+
+    # AR TARGETID, CHECKER
+    d["TARGETID"] = encode_targetid(
+        release=8888, brickid=prognum, objid=np.arange(len(targ))
+    )
+    d["CHECKER"] = checker
+
+    # AR TERTIARY_TARGET
+    dtype = "|S{}".format(np.max([len(x) for x in prios["TERTIARY_TARGET"]]))
+    d["TERTIARY_TARGET"] = np.array(["-" for i in range(len(d))], dtype=dtype)
+    myprios = -99 + np.zeros(len(d))
+    for tertiary_target in np.unique(prios["TERTIARY_TARGET"]):
+        if tertiary_target[:5] == "DESI_":
+            name, dtkey, mask = tertiary_target[5:], "DESI_TARGET", desi_mask
+        if tertiary_target[:4] == "BGS_":
+            name, dtkey, mask = tertiary_target[4:], "BGS_TARGET", bgs_mask
+        if tertiary_target[:4] == "MWS_":
+            name, dtkey, mask = tertiary_target[4:], "MWS_TARGET", mws_mask
+        if tertiary_target[:5] == "SCND_":
+            name, dtkey, mask = tertiary_target[5:], "SCND_TARGET", scnd_mask
+        prio = prios["PRIORITY"][prios["TERTIARY_TARGET"] == tertiary_target][0]
+        sel = ((targ[dtkey] & mask[name]) > 0) & (myprios < prio)
+        # AR assuming all secondaries have OVERRIDE=False
+        # AR i.e. a primary target will keep its properties if it
+        # AR also is a secondary
+        if dtkey == "SCND_TARGET":
+            sel &= targ["DESI_TARGET"] == desi_mask["SCND_ANY"]
+        myprios[sel] = prio
+        d["TERTIARY_TARGET"][sel] = tertiary_target
+
+    # AR verify that all rows got assigned a TERTIARY_TARGET
+    assert (d["TERTIARY_TARGET"] == "").sum() == 0
+
+    # AR verify that we set for PRIORITY_INIT the same values as in desitarget
+    # AR except for STD_BRIGHT,STD_FAINT
+    # AR except for WD_BINARIES_BRIGHT, WD_BINARIES_DARK...
+    # AR            where the above assumption is false.. (their scnd priority
+    # AR            1998 is higher than their primary_priority, 1400-1500
+    # AR            from MWS_BROAD,MWS_MAIN_BLUE..
+    # AR except for (6) GC_BRIGHT in COSMOS/BRIGHT (same reason as above)
+    myprios = -99 + np.zeros(len(d))
+    for t, p in zip(prios["TERTIARY_TARGET"], prios["PRIORITY"]):
+        myprios[d["TERTIARY_TARGET"] == t] = p
+    ignore_std = np.in1d(
+        d["TERTIARY_TARGET"].astype(str), ["DESI_STD_BRIGHT", "DESI_STD_FAINT"]
+    )
+    log.info(
+        "priority_check: ignoring {} DESI_STD_BRIGHT|DESI_STD_FAINT".format(
+            ignore_std.sum()
+        )
+    )
+    ignore_wd = (targ["SCND_TARGET"] & scnd_mask["WD_BINARIES_BRIGHT"]) > 0
+    ignore_wd |= (targ["SCND_TARGET"] & scnd_mask["WD_BINARIES_DARK"]) > 0
+    log.info(
+        "priority check: ignoring {} WD_BINARIES_BRIGHT|WD_BINARIES_DARK".format(
+            ignore_wd.sum()
+        )
+    )
+    ignore = (ignore_std) | (ignore_wd)
+    if prognum == 8:
+        ignore_gcb = (targ["SCND_TARGET"] & scnd_mask["GC_BRIGHT"]) > 0
+        log.info("priority check: ignoring {} GC_BRIGHT".format(ignore_gcb.sum()))
+        ignore |= ignore_gcb
+    sel = (myprios != targ["PRIORITY_INIT"]) & (~ignore)
+    assert sel.sum() == 0
+
+    # AR other columns
+    for key in ["RA", "DEC", "PMRA", "PMDEC", "REF_EPOCH", "SUBPRIORITY"]:
+        d[key] = targ[key]
+    sel = (~np.isfinite(d["REF_EPOCH"])) | (d["REF_EPOCH"] == 0)
+    assert (d["PMRA"][sel] != 0).sum() == 0
+    assert (d["PMDEC"][sel] != 0).sum() == 0
+    d["REF_EPOCH"][sel] = 2015.5
+
+    for key in [
+        "TARGETID",
+        "DESI_TARGET",
+        "BGS_TARGET",
+        "MWS_TARGET",
+        "SCND_TARGET",
+        "PRIORITY_INIT",
+    ]:
+        d["ORIG_{}".format(key)] = targ[key]
+
+    d.write(outfn)

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -200,7 +200,6 @@ def get_calibration_priorities(program):
 
 def get_calibration_targets(
     prognum,
-    targdir,
     priofn=None,
     checker="AR",
     radius=3,

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -13,7 +13,10 @@ from desitarget.targets import encode_targetid
 from desitarget.targetmask import desi_mask, bgs_mask, mws_mask, scnd_mask
 from fiberassign.fba_tertiary_io import get_priofn, get_targfn
 from fiberassign.utils import Logger
-from desisurveyops.fba_tertiary_design_io import create_tiles_table, format_pmradec_refepoch
+from desisurveyops.fba_tertiary_design_io import (
+    create_tiles_table,
+    format_pmradec_refepoch,
+)
 
 # AR https://desi.lbl.gov/trac/wiki/SurveyOps/CalibrationFields
 
@@ -112,13 +115,7 @@ def get_calibration_tile_centers(field_ra, field_dec, ntile):
     return ras, decs
 
 
-def get_calibration_tiles(
-    program,
-    field_ra,
-    field_dec,
-    tileid_start,
-    tileid_end
-):
+def get_calibration_tiles(program, field_ra, field_dec, tileid_start, tileid_end):
 
     ntile = tileid_end - tileid_start + 1
     tileids = np.arange(tileid_start, tileid_end + 1, dtype=int)
@@ -237,7 +234,9 @@ def get_main_primary_targets(
         program.lower(),
     )
     # AR get the file nside
-    fn = sorted(glob(os.path.join(hpdir, "targets-{}-hp-*fits".format(program.lower()))))[0]
+    fn = sorted(
+        glob(os.path.join(hpdir, "targets-{}-hp-*fits".format(program.lower())))
+    )[0]
     nside = fitsio.read_header(fn, 1)["FILENSID"]
     # AR get the list of pixels overlapping the tiles
     tiles = Table()
@@ -365,7 +364,9 @@ def finalize_calibration_target_table(
     d["CHECKER"] = checker
 
     # AR put TARGETID, CHECKER first, for ~backwards-compatibility
-    keys = ["TARGETID", "CHECKER"] + [_ for _ in d.colnames if _ not in ["TARGETID", "CHECKER"]]
+    keys = ["TARGETID", "CHECKER"] + [
+        _ for _ in d.colnames if _ not in ["TARGETID", "CHECKER"]
+    ]
     d = d[keys]
 
     # AR pmra, pmdec, ref_epoch

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -176,7 +176,9 @@ def get_calibration_tiles(program, field_ra, field_dec, tileid_start, tileid_end
     tileras, tiledecs = get_calibration_tile_centers(field_ra, field_dec, ntile)
 
     # AR create + write table
-    d = create_tiles_table(tileids, tileras, tiledecs, program)
+    # AR for backwards-compatibility reasons, we set here
+    # AR    IN_DESI=True (instead of the usual IN_DESI=1
+    d = create_tiles_table(tileids, tileras, tiledecs, program, in_desis=np.ones(ntile, dtype=bool))
 
     return d
 

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -200,14 +200,14 @@ def get_calibration_priorities(program):
 
 def get_calibration_targets(
     prognum,
+    program,
+    field_ra,
+    field_dec,
+    radius,
     priofn=None,
     checker="AR",
-    radius=3,
     dtver="1.1.1",
 ):
-
-    # AR program + field center
-    program, field_ra, field_dec, _, _ = get_calibration_settings(prognum)
 
     # AR tertiary priorities
     if priofn is not None:

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -134,7 +134,7 @@ def get_calibration_tiles(prognum):
     return d
 
 
-def get_calibration_priorities(prognum, program):
+def get_calibration_priorities(program):
 
     # AR keys
     keys = ["TERTIARY_TARGET", "NUMOBS_DONE_MIN", "NUMOBS_DONE_MAX", "PRIORITY"]

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -178,7 +178,9 @@ def get_calibration_tiles(program, field_ra, field_dec, tileid_start, tileid_end
     # AR create + write table
     # AR for backwards-compatibility reasons, we set here
     # AR    IN_DESI=True (instead of the usual IN_DESI=1
-    d = create_tiles_table(tileids, tileras, tiledecs, program, in_desis=np.ones(ntile, dtype=bool))
+    d = create_tiles_table(
+        tileids, tileras, tiledecs, program, in_desis=np.ones(ntile, dtype=bool)
+    )
 
     return d
 
@@ -233,7 +235,11 @@ def get_main_primary_priorities(program):
         for name in mask_names:
             if program in mask[name].obsconditions:
                 names.append("{}_{}".format(prefix, name))
-                initprios.append(mask[name].priorities["UNOBS"] if "UNOBS" in mask[name].priorities else None)
+                initprios.append(
+                    mask[name].priorities["UNOBS"]
+                    if "UNOBS" in mask[name].priorities
+                    else None
+                )
                 calib_or_nonstds.append("UNOBS" not in mask[name].priorities)
 
     names = np.array(names)
@@ -354,7 +360,9 @@ def get_main_primary_targets_names(
         assert initprios is not None
     else:
         assert initprios is None
-        tertiary_targets, initprios, calib_or_nonstds = get_main_primary_priorities(program)
+        tertiary_targets, initprios, calib_or_nonstds = get_main_primary_priorities(
+            program
+        )
     sel = np.array([_ is not None for _ in initprios])
     tertiary_targets, initprios = tertiary_targets[sel], initprios[sel]
 
@@ -395,9 +403,7 @@ def get_main_primary_targets_names(
     myprios = -99 + np.zeros(len(targ))
     for t, p in zip(tertiary_targets, initprios):
         myprios[names == t] = p
-    ignore_std = np.in1d(
-        names.astype(str), ["DESI_STD_BRIGHT", "DESI_STD_FAINT"]
-    )
+    ignore_std = np.in1d(names.astype(str), ["DESI_STD_BRIGHT", "DESI_STD_FAINT"])
     log.info(
         "priority_check: ignoring {} DESI_STD_BRIGHT|DESI_STD_FAINT".format(
             ignore_std.sum()

--- a/py/desisurveyops/fba_calibration_design_io.py
+++ b/py/desisurveyops/fba_calibration_design_io.py
@@ -111,12 +111,14 @@ def get_tile_centers(field_ra, field_dec, ntile):
     return ras, decs
 
 
-def get_calibration_tiles(prognum):
+def get_calibration_tiles(
+    program,
+    field_ra,
+    field_dec,
+    tileid_start,
+    tileid_end
+):
 
-    # AR tiles list settings
-    program, field_ra, field_dec, tileid_start, tileid_end = get_calibration_settings(
-        prognum
-    )
     ntile = tileid_end - tileid_start + 1
     tileids = np.arange(tileid_start, tileid_end + 1, dtype=int)
     log.info(


### PR DESCRIPTION
This PR adds the scripts / modifications used to design the calibration tiles (`PROGNUM=5,6,7,8,9,10,11,12`).

Until now I was using "not-official" scripts.
This PR adds official scripts / modifications to existing official scripts, which provide similar outputs.
I have done my best to follow/insert in the tertiary scheme that has been developed after the initial calibration scripts.

A small inconvenience is the `fba_launch [...] --custom_too_development` call, due to this technical point:
- with my custom scripts, I was designing tiles with the `fiberassign/5.7.0` tag version, because it enables the use of multiple ToO files for a tile (the Main one, and the tertiary one; this PR: https://github.com/desihub/fiberassign/pull/437).
- but, this requires that the ToO files are in the `$DESI_SURVEYOPS` folder, out of caution.
- so, when designing calibration tiles with my custom scripts, I had to first generate the `ToO-PROGNUMPAD-TILEIDPAD.ecsv` file, svn-commit it to surveyops, and wait for the cron job to pick it up in `$DESI_SURVEYOPS`; I could then generate the fiberassign files, with pointing to `$DESI_SURVEYOPS` for the tertiary ToO file.

But this procedure is a bit painful (and not great when we design tiles in a rush).
So I streamlined that using the `desi_fba_tertiary_wrapper` script -- with small additions, which generates both the ToO file and the fiberassign files;
The "price to pay" is to add this `--custom_too_development` argument.
Because of this "feature", I have been designing other tertiary programs with the `fiberassign/5.6.0` version.
We can discuss if there is a way out here (I am thinking of a modification in fiberassign, which would also allow ToO files from `$DESI_ROOT/survey/fiberassign`).

Further remarks:

- I use conveniency functions from desihub/desimodel (to play around with healpix pixels and tiles): this formally introduces a dependency on desimodel, though the dependency was already there through the fiberassign and desitarget functions; if that is a problem, I could of course re-create those small functions;
- I have verified for `PROGNUM=5` that I can reproduce the initial files (tiles, priorities, targets), one fiberassign design (tileid=83000), and a new fiberassign design (tileid=83006);
- the new code requires that the initial products and the `ToO-PROGNUMPAD-TILEIDPAD.ecsv` files are in the folder where the fiberassign is done (`$DESI_ROOT/survey/fiberassign/special/tertiary`); so I have copied those from `$DESI_SURVEYOPS` with:
```
for PROGNUM in 5 6 7 8 9 10 11 12
do
    PROGNUMPAD=`echo $PROGNUM | awk '{printf("%04d\n", $1)}'`
    cp -p $DESI_SURVEYOPS/tertiary/$PROGNUMPAD/* $DESI_ROOT/survey/fiberassign/special/tertiary/$PROGNUMPAD/
done
```