### PR TITLE
Add script to check fba intermediate corrupted files

### DIFF
--- a/bin/check_fa_intermediate_corrupt
+++ b/bin/check_fa_intermediate_corrupt
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+
+import os
+from glob import glob
+from datetime import datetime
+import multiprocessing
+import fitsio
+import numpy as np
+from astropy.table import Table
+from desiutil.log import get_logger
+from argparse import ArgumentParser
+
+log = get_logger()
+
+allowed_cases = ["tiles", "sky", "targ", "scnd", "too", "gfa"]
+default_fbadir = os.path.join(os.getenv("DESI_ROOT"), "survey", "fiberassign", "main")
+
+
+def parse():
+    parser = ArgumentParser(
+        description="This scripts verifies that the fiberassign intermediate files are not corrupted."
+    )
+    parser.add_argument(
+        "--cases",
+        help="csv list of cases of files to check (default={})".format(
+            ",".join(allowed_cases)
+        ),
+        type=str,
+        default=",".join(allowed_cases),
+    )
+    parser.add_argument(
+        "--fbadir",
+        help="folder with the fiberassign intermediate products (default={})".format(
+            default_fbadir
+        ),
+        type=str,
+        default=default_fbadir,
+    )
+    parser.add_argument(
+        "--outecsv",
+        help="ecsv output file (default=None, i.e. nothing written)",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--overwrite",
+        help="overwrite args.outfn",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--numproc",
+        help="number of concurrent processes to use; set to 0 to not process (default=1)",
+        type=int,
+        default=1,
+    )
+    args = parser.parse_args()
+    assert np.all(np.in1d(args.cases.split(","), allowed_cases))
+    for kwargs in args._get_kwargs():
+        log.info("{}\t{}".format(kwargs[0], kwargs[1]))
+    return args
+
+
+def test_fn(fn, key):
+    try:
+        hdr = fitsio.read_header(fn, 1)
+        _ = fitsio.read(fn, rows=[hdr["NAXIS2"] - 1], columns=key)
+        return None
+    except OSError:
+        return fn
+
+
+def get_timestamp_ymd(fn):
+    return datetime.fromtimestamp(os.path.getmtime(fn)).strftime("%Y-%m-%d")
+
+
+def main():
+
+    args = parse()
+
+    bug_tileids = np.zeros(0, dtype=object)
+    bug_cases = np.zeros(0, dtype=object)
+    bug_timestamps = np.zeros(0, dtype=object)
+
+    for case in args.cases.split(","):
+
+        # AR key used in the reading
+        if case == "tiles":
+            key = "TILEID"
+        else:
+            key = "TARGETID"
+
+        # AR list of files to check
+        fns = sorted(
+            glob(os.path.join(args.fbadir, "???", "??????-{}.fits".format(case)))
+        )
+        log.info("check {} ??????-{}.fits files".format(len(fns), case))
+
+        # AR check
+        myargs = [(fn, key) for fn in fns]
+        pool = multiprocessing.Pool(args.numproc)
+        with pool:
+            bugfns = pool.starmap(test_fn, myargs)
+        bugfns = np.sort([_ for _ in bugfns if _ is not None])
+        log.info("found {} corrupted files".format(len(bugfns)))
+
+        # AR reformat in a more user-friendly way
+        for bugfn in bugfns:
+            tileid = int(os.path.basename(bugfn).split("-")[0])
+            timestamp = get_timestamp_ymd(bugfn)
+            ii = np.where(bug_tileids == tileid)[0]
+            if ii.size > 0:
+                i = ii[0]
+                bug_cases[i] = "{},{}".format(bug_cases[i], case)
+                if timestamp not in bug_timestamps[i].split(","):
+                    bug_timestamps[i] = "{},{}".format(bug_timestamps[i], timestamp)
+            else:
+                bug_tileids = np.append(bug_tileids, tileid)
+                bug_cases = np.append(bug_cases, case)
+                bug_timestamps = np.append(bug_timestamps, timestamp)
+
+    # AR print
+    d = Table()
+    d["TILEID"], d["CASE"], d["TIMESTAMP"] = bug_tileids, bug_cases, bug_timestamps
+    d["CASE"] = d["CASE"].astype(str)
+    d["TIMESTAMP"] = d["TIMESTAMP"].astype(str)
+    ii = np.lexsort([d["CASE"], d["TILEID"], d["TIMESTAMP"]])
+    d = d[ii]
+
+    print("")
+    print(
+        "Found {} corrupted tileids, generated on: {}".format(
+            len(d), np.unique(d["TIMESTAMP"]).tolist()
+        )
+    )
+    print("")
+    print(d)
+    print("")
+
+    # AR write if asked to
+    if args.outecsv is not None:
+        d.write(args.outecsv, overwrite=args.overwrite)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/check_fa_intermediate_corrupt
+++ b/bin/check_fa_intermediate_corrupt
@@ -44,7 +44,7 @@ def parse():
     )
     parser.add_argument(
         "--overwrite",
-        help="overwrite args.outfn",
+        help="overwrite args.outecsv",
         action="store_true",
     )
     parser.add_argument(

--- a/bin/check_fa_intermediate_corrupt
+++ b/bin/check_fa_intermediate_corrupt
@@ -49,7 +49,7 @@ def parse():
     )
     parser.add_argument(
         "--numproc",
-        help="number of concurrent processes to use; set to 0 to not process (default=1)",
+        help="number of concurrent processes to use (default=1)",
         type=int,
         default=1,
     )


### PR DESCRIPTION
@LNapolitano reported that the alt-mtl code stumbles on a corrupted intermediate fiberassign file (`010465-sky.fits`): https://desisurvey.slack.com/archives/C01HNN87Y7J/p1741808490640129

This PR adds a small script to loop through all main survey tiles intermediate fiberassign files, i.e. all `??????-{tiles,sky,gfa,targ,scnd,too}.fits` files:
```
usage: check_fa_intermediate_corrupt [-h] [--cases CASES] [--fbadir FBADIR] [--outecsv OUTECSV] [--overwrite] [--numproc NUMPROC]

This scripts verifies that the fiberassign intermediate files are not corrupted.

options:
  -h, --help         show this help message and exit
  --cases CASES      csv list of cases of files to check (default=tiles,sky,targ,scnd,too,gfa)
  --fbadir FBADIR    folder with the fiberassign intermediate products (default=/global/cfs/cdirs/desi/survey/fiberassign/main)
  --outecsv OUTECSV  ecsv output file (default=None, i.e. nothing written)
  --overwrite        overwrite args.outfn
  --numproc NUMPROC  number of concurrent processes to use; set to 0 to not process (default=1)
```

It s pretty fast if run from an interactive node (<2min to check ~100k files, using `--numproc 256`).

The check is to try to open the file at the last row using the `NAXIS2` header value.

So far, it reports the following corrupted files, coming from 34 tiles:
```
TILEID        CASE       TIMESTAMP 
------ ----------------- ----------
  3475 sky,targ,scnd,gfa 2024-06-15
 11267           sky,gfa 2024-06-15
 11276               sky 2024-06-15
 21619      sky,targ,gfa 2024-06-15
 21789      sky,targ,gfa 2024-06-15
 22771 sky,targ,scnd,gfa 2024-06-15
 23146 sky,targ,scnd,gfa 2024-06-15
 23345 sky,targ,scnd,gfa 2024-06-15
 24705               sky 2024-06-15
  9688              targ 2024-08-12
  1326              scnd 2024-12-02
  1967              targ 2024-12-02
  9174              targ 2024-12-02
  9739          targ,gfa 2024-12-02
 23324              targ 2024-12-10
 25072               gfa 2024-12-10
 26154              scnd 2024-12-10
 26484              scnd 2024-12-10
 27084               gfa 2024-12-10
  1345               sky 2025-02-21
  1358     sky,targ,scnd 2025-02-21
  2142              targ 2025-02-21
  2945      sky,targ,gfa 2025-02-21
  2947               sky 2025-02-21
  2954     targ,scnd,gfa 2025-02-21
  2958              scnd 2025-02-21
  3667              scnd 2025-02-21
  4511               sky 2025-02-21
  6058           sky,gfa 2025-02-21
  6805          targ,gfa 2025-02-21
  6832           sky,gfa 2025-02-21
  7634      sky,targ,gfa 2025-02-21
  9742      sky,targ,gfa 2025-02-21
 10036               sky 2025-02-21
```

Those tiles were generated on few days ('2024-06-15', '2024-08-12', '2024-12-02', '2024-12-10', '2025-02-21'):
- 2024-06-15 => after maintenance (2024-06-9to12: HPSS regent maintenance, perlmutter degraded on 2024-06-14)
- 2024-08-12 => nothing particular just before, though some nersc action before/after
- 2024-12-02 => nothing particular just before, though some nersc action after
- 2024-12-10 => during HPSS Archive (User) Scheduled Maintenance
- 2025-02-21 => just after a perlmutter maintenance

@LNapolitano: could I let you take over from here? like:
- double-check this list of corrupted files
- "fix" those in the same way you did for `010465-sky.fits`? given the number the number of tiles, I guess you d want to somewhat automate the procedure...
- ideally document that procedure somewhere in the wiki?

thanks!


