### PR TITLE
Status skymaps display

### DIFF
--- a/py/desisurveyops/status_sky.py
+++ b/py/desisurveyops/status_sky.py
@@ -655,7 +655,7 @@ def plot_skymap(
     if quant == "fraccov":
         cmap = get_quantz_cmap(matplotlib.cm.jet, 11, 0, 1)
         cmaplist = [cmap(i) for i in range(cmap.N)]
-        cmaplist[0] = ListedColormap(["lightgray"])(0)
+        #cmaplist[0] = ListedColormap(["lightgray"])(0)
         cmap = LinearSegmentedColormap.from_list("Custom cmap", cmaplist, cmap.N)
         cmin, cmax = 0, 1
         clabel = "Fraction of final coverage"
@@ -747,7 +747,10 @@ def plot_skymap(
     ax = fig.add_subplot(111, projection="mollweide")
     ax = init_sky(galactic_plane_color="none", ecliptic_plane_color="none", ax=ax)
     ax.set_axisbelow(True)
-    sel = ns >= 0
+    if quant == "ntile":
+        sel = ns >= 0
+    if quant == "fraccov":
+        sel = ns > 0
     sc = ax.scatter(
         ax.projection_ra(d["RA"][sel]),
         ax.projection_dec(d["DEC"][sel]),
@@ -762,6 +765,23 @@ def plot_skymap(
         vmax=cmax,
         zorder=0,
     )
+    # AR fraccov: now plot as gray tiles with zero observations
+    if quant == "fraccov":
+        sel = ns == 0
+        ax.scatter(
+            ax.projection_ra(d["RA"][sel]),
+            ax.projection_dec(d["DEC"][sel]),
+            c="lightgray",
+            #facecolors=ns,
+            marker=".",
+            s=0.1,
+            linewidths=0,
+            alpha=0.8,
+            cmap=cmap,
+            vmin=cmin,
+            vmax=cmax,
+            zorder=0,
+        )
     ax.set_title(title)
 
     # AR DES, galactic, ecliptic plane

--- a/py/desisurveyops/status_sky.py
+++ b/py/desisurveyops/status_sky.py
@@ -634,6 +634,9 @@ def plot_skymap(
         #ntilemax = goal_ns.max()
         # AR ignore few percents pixels where goal_ns is inaccurate because of tiles2pix()
         ntilemax = int(np.percentile(goal_ns[goal_ns > 0], 99.))
+        # AR clip (because of BRIGHT1B which can have 35+ in M31)
+        ntile_clipmax = 10
+        ntilemax = np.min([ntilemax, ntile_clipmax])
         cmap = get_quantz_cmap(matplotlib.cm.jet, ntilemax + 1, 0, 1)
         cmaplist = [cmap(i) for i in range(cmap.N)]
         cmaplist[0] = ListedColormap(["lightgray"])(0)
@@ -645,6 +648,9 @@ def plot_skymap(
         else:
             dn = 1
         cticks = np.arange(0, ntilemax + dn, dn, dtype=int)
+        cticklabels = cticks.astype(str)
+        if ntilemax == ntile_clipmax:
+            cticklabels[-1] += "+"
 
     if quant == "fraccov":
         cmap = get_quantz_cmap(matplotlib.cm.jet, 11, 0, 1)
@@ -654,6 +660,7 @@ def plot_skymap(
         cmin, cmax = 0, 1
         clabel = "Fraction of final coverage"
         cticks = np.arange(0, 1.1, 0.1)
+        cticklabels = np.array(["{:.1f}".format(_) for _ in cticks])
 
     # AR healpix
     npix = hp.nside2npix(nside)
@@ -830,6 +837,7 @@ def plot_skymap(
     cbar = plt.colorbar(sc, cax=cax, fraction=0.025, orientation="horizontal")
     cbar.set_label(clabel)
     cbar.set_ticks(cticks)
+    cbar.set_ticklabels(cticklabels)
 
     # AR blank region for text
     ax.fill_between(


### PR DESCRIPTION
This PR makes small modifications to the display of the coverage sky maps on the main status page:
- for plots displaying the number of covering tiles, the colorbar is now clipped to 10 (that value can be changed, of course); the motivation is the `BRIGHT1B/M31` subprogram, where the colorbar otherwise goes up to 35, hence making it useless, as everything ends up in blue
- for plots displaying the coverage fraction, the gray color is now attributed only to regions with `fraccov=0`, whereas it was previously for `fraccov<0.1` (initially because, before the `BRIGHT1B` program, those two cases would be the same).

Here s the old ntile plot:
<img width="2557" height="1334" alt="main-bright1b-skymap-obs-ntile (1)" src="https://github.com/user-attachments/assets/7597bb4d-1967-46e7-a45b-c7a80ea0408b" />
and the new ntile plot (the difference in the weighted fraction probably comes from some bug in the `main` code, I need to investigate that):
<img width="2557" height="1334" alt="main-bright1b-skymap-obs-20250823-ntile" src="https://github.com/user-attachments/assets/11736646-2b69-41ca-968d-e24910f2634f" />

And here s the old fraccov plot:
<img width="2557" height="1334" alt="main-bright1b-skymap-obs-fraccov (1)" src="https://github.com/user-attachments/assets/546501b2-3805-4705-8b84-84d59ff0ec91" />
and the new fraccov plot:
<img width="2557" height="1334" alt="main-bright1b-skymap-obs-20250823-fraccov" src="https://github.com/user-attachments/assets/10a90d1f-cc3a-4b0e-872e-a82b2c706e76" />


