### PR TITLE
fba_validate: bugfix

### DIFF
--- a/bin/validate_lastnight_fba
+++ b/bin/validate_lastnight_fba
@@ -104,7 +104,7 @@ if docheck:
         dfn = outdir+'/'+str(tidl[ii])+'.diff'
         if os.path.isfile(fnl[ii]):
             fba_rerun_check(fol[ii], fnl[ii],dfn )  
-            if len(open(dfn).readlines())<1:
+            if len(open(dfn).readlines())>1:
                 tids = np.genfromtxt(dfn,usecols = (3))
                 if len(tids) > 0:
                     #tids = dd[3]


### PR DESCRIPTION
This PR fixes a possibly unfortunate bug in the `validate_lastnight_fba` script.

the `dfn` in the code is the fiberassign diff file (rerun vs. orig).
if the rerun reproduces the orig, this diff file should have a single (header) line.
if the rerun doesn t reproduce the orig, this diff file will contain the differences, hence will have more than the single header line.

this if condition is to decide if the code further checks the diff file.
because of that typo, I think the code actually never performs any check… that typo is there from the beginning.

kudos to @sbailey who spotted an issue in the `$SKYHEALPIXS_DIR` definition with the `desiproc` user, which should break the reproducibility in `validate_lastnight_fba`, but didn't.

the issue was that `$SKYHEALPIXS_DIR=/target/skyhealpixs/v1` (ie without the `$DESI_ROOT`).
I confirm that e.g. running for 20250826 with this PR and this buggy `$SKYHEALPIXS_DIR` reports failures (for backup and some bright1b tiles, which use gaia lookup_sky_source):
```
validate_lastnight_fba --night 20250826 --outroot xxx
[...]
found 4 positive targetid that are different
FOLLOW-UP NEEDED, DO NOT ALLOW ZDONE FOR TILEID 40417!!!
found 4 positive targetid that are different
FOLLOW-UP NEEDED, DO NOT ALLOW ZDONE FOR TILEID 43453!!!
found 808 positive targetid that are different
FOLLOW-UP NEEDED, DO NOT ALLOW ZDONE FOR TILEID 43900!!!
found 22 positive targetid that are different
FOLLOW-UP NEEDED, DO NOT ALLOW ZDONE FOR TILEID 45345!!!
[...]
found 740 positive targetid that are different
FOLLOW-UP NEEDED, DO NOT ALLOW ZDONE FOR TILEID 122908!!!
found 752 positive targetid that are different
FOLLOW-UP NEEDED, DO NOT ALLOW ZDONE FOR TILEID 123133!!!
found 772 positive targetid that are different
FOLLOW-UP NEEDED, DO NOT ALLOW ZDONE FOR TILEID 123179!!!
[...]
FAIL!!! at lease one tile failed; investigate output above
```

