### PR TITLE
Ignore bright1b pass 5 when computing statistics

### DIFF
--- a/py/desisurveyops/status_sky.py
+++ b/py/desisurveyops/status_sky.py
@@ -121,6 +121,7 @@ def process_skymap(
         ## filler pass to use when there is nothing else to observe
         if program == 'BRIGHT1B':
             log.warning(f"For PROGRAM=BRIGHT1B ignoring PASS=5")
+            fn = fns["ops"]["tiles"]
             t = Table.read(fn)
             t = t[t["PASS"] != 5]
             sel &= np.in1d(obs_tiles, t["TILEID"])

--- a/py/desisurveyops/status_sky.py
+++ b/py/desisurveyops/status_sky.py
@@ -1449,7 +1449,7 @@ def plot_sky_pending(
     ## AK: ignore pass 5 of bright1b which is a very low priority filler program
     ## for when we have nothing better to observe in bright conditions
     if program == 'BRIGHT1B':
-	sel &= t["PASS"] != 5
+        sel &= t["PASS"] != 5
     t = t[sel]
 
     # AR add some columns from tiles-specstatus

--- a/py/desisurveyops/status_sky.py
+++ b/py/desisurveyops/status_sky.py
@@ -117,6 +117,14 @@ def process_skymap(
             t = Table.read(fn)
             t = t[t["PASS"] < npassmax]
             sel &= np.in1d(obs_tiles, t["TILEID"])
+        ## AK: for sky completeness, let's ignore pass 5 which is a very low priority
+        ## filler pass to use when there is nothing else to observe
+        if program == 'BRIGHT1B':
+            log.warning(f"For PROGRAM=BRIGHT1B ignoring PASS=5")
+            t = Table.read(fn)
+            t = t[t["PASS"] != 5]
+            sel &= np.in1d(obs_tiles, t["TILEID"])
+        
         log.info("{}\tfound {} observed tiles".format(program_str, sel.sum()))
 
         # AR handle e.g. bright1b which does not exist yet
@@ -460,6 +468,11 @@ def create_skygoal(tilesfn, program, outfn=None, nside=1024, npassmax=None):
     sel &= t["IN_DESI"]
     if npassmax is not None:
         sel &= t["PASS"] < npassmax
+    ## AK: ignore PASS 5 of BRIGHT1B which is a very low priority filler layer
+    ## used when nothing else is available during bright time
+    if program == 'BRIGHT1B':
+        sel &= t['PASS'] != 5
+        
     t = t[sel]
     if npassmax is not None:
         log.info(
@@ -585,6 +598,13 @@ def plot_skymap(
     sel &= t["IN_DESI"]
     if npassmax is not None:
         sel &= t["PASS"] < npassmax
+    
+    ## AK: for sky completeness, let's ignore pass 5 which is a very low priority                                                                                                                   
+    ## filler pass to use when there is nothing else to observe                                                                                                                                     
+    if program == 'BRIGHT1B':
+        log.warning(f"For PROGRAM=BRIGHT1B ignoring PASS=5")
+        sel &= t["PASS"] != 5
+
     t = t[sel]
     passids = np.unique(t["PASS"])
     npass = len(passids)
@@ -1208,6 +1228,12 @@ def plot_skycompl_ralst(
     sel &= t["IN_DESI"]
     if npassmax is not None:
         sel &= t["PASS"] < npassmax
+
+    ## AK: ignore pass 5 of bright1b which is a very low priority filler program
+    ## for when we have nothing better to observe in bright conditions
+    if program == 'BRIGHT1B':
+        sel &= t["PASS"] != 5
+        
     t = t[sel]
 
     # AR cap
@@ -1420,6 +1446,10 @@ def plot_sky_pending(
     sel &= (t["STATUS"] != "unobs") & (t["STATUS"] != "done")
     if npassmax is not None:
         sel &= t["PASS"] < npassmax
+    ## AK: ignore pass 5 of bright1b which is a very low priority filler program
+    ## for when we have nothing better to observe in bright conditions
+    if program == 'BRIGHT1B':
+	sel &= t["PASS"] != 5
     t = t[sel]
 
     # AR add some columns from tiles-specstatus

--- a/py/desisurveyops/status_sky.py
+++ b/py/desisurveyops/status_sky.py
@@ -599,8 +599,8 @@ def plot_skymap(
     if npassmax is not None:
         sel &= t["PASS"] < npassmax
     
-    ## AK: for sky completeness, let's ignore pass 5 which is a very low priority                                                                                                                   
-    ## filler pass to use when there is nothing else to observe                                                                                                                                     
+    ## AK: for sky completeness, let's ignore pass 5 which is a very low priority
+    ## filler pass to use when there is nothing else to observe
     if program == 'BRIGHT1B':
         log.warning(f"For PROGRAM=BRIGHT1B ignoring PASS=5")
         sel &= t["PASS"] != 5

--- a/py/desisurveyops/status_spacewatch.py
+++ b/py/desisurveyops/status_spacewatch.py
@@ -418,6 +418,11 @@ def spacewatch_night(
         t += tdelta
     log.info("night = {} -> found {} spacewatch images".format(night, len(fns)))
 
+    ## On nights when the allsky camera is non-operational, we don't have any files
+    if len(fns) == 0:
+        log.warning(f"No allsky camera images on night {night}")
+        return
+
     # image
     fn = fns[0]
     img = np.asarray(Image.open(fn))


### PR DESCRIPTION
This code has been running in production for over a month. The purpose is to remove pass 5 when computing bright1b completion statistics since that is a very low priority filler program meant to give us something to observe when we need them, but they shouldn't count against us if we don't observe them.

This has also accumulated a few other fixes, including resolve the spacewatch indexing error (in issue #343).

I will self merge this and continue monitoring the daily outputs to make sure it does the right thing.