### PR TITLE
Fix: added atleast_1d to TARGETID read from diff file

### DIFF
--- a/bin/validate_lastnight_fba
+++ b/bin/validate_lastnight_fba
@@ -105,7 +105,7 @@ if docheck:
         if os.path.isfile(fnl[ii]):
             fba_rerun_check(fol[ii], fnl[ii],dfn )  
             if len(open(dfn).readlines())>1:
-                tids = np.atleast_1d(np.genfromtxt(dfn,usecols = (3)))
+                tids = np.atleast_1d(np.genfromtxt(dfn, usecols = (3,), dtype=int))
                 if len(tids) > 0:
                     #tids = dd[3]
                     sel = tids > 0


### PR DESCRIPTION
Discussed here: https://github.com/desihub/desisurveyops/issues/376. When TILEIDs are being checked at the end of the validate_lastnight_fba script an array of TARGETID values is read from the {TILEID}.diff file. If a single diff was present the array returned was 0-dimensional, which would throw a TypeError when passed to len(). This change ensures the array of TARGETID values is always at least 1-dimensional