### PR TITLE
nspec plots: set xticks to anniversary dates of 20210514

### DIFF
--- a/py/desisurveyops/status_nspec.py
+++ b/py/desisurveyops/status_nspec.py
@@ -748,11 +748,12 @@ def plot_nspec(survey, nspecfn, nspecpng):
 
 
 # AR see email Sam Brieden from Feb. 22, 2024
-def plot_nspec_summary(specfn, firstnight, lastnight, outpng):
+def plot_nspec_summary(survey, specfn, firstnight, lastnight, outpng):
     """
     Make a simplified version of the nspec=f(night) plot.
 
     Args:
+        survey: survey name (str)
         specfn: full path to the nspec.ecsv file (str)
         firstnight: first night to consider (int)
         lastnight: last night to consider (int)


### PR DESCRIPTION
This PR implements a small change in the https://data.desi.lbl.gov/desi/survey/ops/main-status/nspec/main-nspec.png plot: it sets the xticks to be at the anniversary dates of 20210514, ie the start of the main survey.

Currently, the xticks are chosen in a dynamical way, like 5-6 values between 20210514 and the current day.
With this PR, it will be 20210514, 20220514, 20230514, etc:
<img width="1633" height="495" alt="main-nspec-pr" src="https://github.com/user-attachments/assets/9d0880a7-3827-44cd-8cbf-4be44938c3f9" />

That is a suggestion from Nathalie.
One advantage of these xticks is that one can easily read, for instance: in 3 yrs, desi observed 30+M galaxies/qsos and 10+M stars.
At the end of survey, there should be 20210514, 20220514, ...,  20280514, 20290101, ie 9 xticks, so not too crowded.

This PR also fixes a small bug in the `status_nspec.plot_nspec_summary()` function, which is not used in the webpage.
But it provides a nice, compressed plot, for talks, advertising it here:
<img width="288" height="240" alt="main-nspec-summary" src="https://github.com/user-attachments/assets/2e020f55-76f2-4c42-9694-54c532ce0e27" />