### PR TITLE
compute_nspec(): try to avoid OOM-error; remove parallelization

### DIFF
--- a/py/desisurveyops/status_nspec.py
+++ b/py/desisurveyops/status_nspec.py
@@ -431,7 +431,6 @@ def compute_nspec_prog_name_thrunight(zmtl, progshort, name):
     Args:
         zmtl: astropy.table.Table concatenation of the zmtl-YYYY.fits file,
             "pre-processed" (see Notes)
-        isprogs: dictionary listing the tileids for each program (dict)
         progshort: the program name (without the 1B) (str)
         name: custom names of subsamples:
             "MWS_ANY", "BGS_BRIGHT", "BGS_FAINT"


### PR DESCRIPTION
Here s another attempt to address https://github.com/desihub/desisurveyops/issues/408#issuecomment-3764237497.

Still no major change here, I simply did the following in `compute_nspec()`.
- the 15 per-program, per-tracer calls to `compute_nspec_prog_name_thrunight()` were done using multiprocessing; as each call requires this massive `zmtl` table, it may be the reason of the OOM-error; I have simply turned that into a loop
- besides `compute_nspec_prog_name_thrunight()` input catalog should already be cut on the program, hopefully that could help reduce the overall used memory

I also happen here to fix a (luckily!) harmless bug in the call to `compute_nspec()`.

The code runs on my side (and faster than before the pr: 300s vs. 800s for `compute_nspec()`).

I think I ll merge this PR, hoping that it will be picked up and used for the processing of 20260118, and we can see if it runs.
I apologize for using this "merge the PR and see if it works" approach, but I don t see another way to test if the scron job will run.