### PR TITLE
Include LYA in UNQ_ALL.

### DIFF
--- a/py/desisurveyops/status_nspec.py
+++ b/py/desisurveyops/status_nspec.py
@@ -489,7 +489,6 @@ def compute_nspec_prog_name_thrunight(zmtl, progshort, name):
         ("UNQ_GALQSO", (zmtl["ZOK"]) & (~zmtl["ZSTAR"])),
         ("UNQ_LYA", zmtl["LYA"]),
         ("UNQ_ALL", (zmtl["ZOK"]) | (zmtl["LYA"])),
-        ("UNQ_ALL", zmtl["ZOK"]),
     ]:
         jj = np.where(sel)[0]
         jj = jj[np.isin(jj, ii)]
@@ -649,6 +648,7 @@ def plot_nspec(survey, nspecfn, nspecpng):
             names = ["ALL"]
             cols = ["k"]
         else:
+            import sys
             sys.exit("wrong prog; exiting")
 
         for name, col in zip(names, cols):


### PR DESCRIPTION
This PR changes the definition of `UNQ_ALL` to include `ZLYA`, per the discussion on #418. I've run a test and the code works without failing, and since nspec is calculated anew each day no reprocessing is necessary. The test is in my $CFS at `dylang/surveyops/main-status.html`

I also fixed an as-yet-unencountered bug where sys.exit was called without importing sys. I don't think we'll ever encounter this, but I preemptively fixed it anyway. 