### PR TITLE
Default to using --force_try_too_all in fba_launch for validate_lastnight_fba

### DIFF
--- a/bin/validate_lastnight_fba
+++ b/bin/validate_lastnight_fba
@@ -20,6 +20,10 @@ parser.add_argument("--outroot", default=None, type=str,
         help="root directory for final outputs ($DESI_ROOT/survey/fiberassign/main)")
 parser.add_argument("--overwrite", default=False, action='store_true',
         help="overwrite final outputs in outroot")
+parser.add_argument("--oldstyletoo", default=False, action="store_true",
+        help=("Use the style of ToO file from the first part of the DESI "
+        "survey, before the addition of Rubin ToOs")
+        )
 
 args = parser.parse_args()
 
@@ -93,14 +97,20 @@ for tid in tidl:
     fol.append(fn)
     fnl.append(outdir+'/'+str(tid).zfill(6)[:3]+'/fiberassign-'+str(tid).zfill(6)+'.fits.gz')
     #system call run fiberassign
-    os.system('fba_rerun --infiberassign '+fn+' --outdir '+outdir+' --nosteps qa') #--dtver 1.1.1 
+    # ADM updated for new style of ToO file.
+    # ADM see https://github.com/desihub/fiberassign/pull/500
+    # ADM and https://github.com/desihub/desitarget/pull/874
+    if args.oldstyletoo:
+        os.system('fba_rerun --infiberassign '+fn+' --outdir '+outdir+' --nosteps qa') #--dtver 1.1.1
+    else:
+        os.system('fba_rerun --infiberassign '+fn+' --outdir '+outdir+' --nosteps qa --force_try_too_all') #--dtver 1.1.1
 
 from fiberassign.fba_rerun_io import fba_rerun_check
 docheck = True
 
 tids_passl = []
 if docheck:
-    for ii in range(0,len(fnl)):
+    for ii in range(0, len(fnl)):
         dfn = outdir+'/'+str(tidl[ii])+'.diff'
         if os.path.isfile(fnl[ii]):
             fba_rerun_check(fol[ii], fnl[ii],dfn )  
@@ -138,7 +148,7 @@ for tid in tids_passl:
     for name in ["tiles", "sky", "gfa", "targ", "scnd", "too"]:        
         fn = outdir+'/'+str(tid).zfill(6)[:3]+'/'+str(tid).zfill(6)+'-'+name+'.fits'
         if os.path.isfile(fn):
-            mv_fn =os.path.join(mv_tiddir, os.path.basename(fn))
+            mv_fn = os.path.join(mv_tiddir, os.path.basename(fn))
             if os.path.exists(mv_fn) and not args.overwrite:
                     print(f'Not overwriting {mv_fn}')
             else:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -4,5 +4,8 @@ desisurveyops
 0.0.1 (unreleased)
 ------------------
 
-* No changes yet
+* Use `--force_try_too_all` in `validate_lastnight_fba` [`PR #435`_].
+
+.. _`PR #435`: https://github.com/desihub/desisurveyops/pull/435
+
 


### PR DESCRIPTION
This PR updates the default call to `fba_launch` in `validate_lastnight_fba` to use the `--force_try_too_all` switch that was implemented in https://github.com/desihub/fiberassign/pull/500.

To be safe, `validate_lastnight_fba` can be forced to _not_ use the new `--force_try_too_all` switch by passing `--oldstyletoo`. This means we should be able to easily restore the currently-working default behavior if anything goes wrong.

I've tested this by running calls like:

`validate_lastnight_fba --outroot /pscratch/sd/a/adamyers/blatfba`
`validate_lastnight_fba --outroot /pscratch/sd/a/adamyers/blatfbaoldstyle --oldstyletoo`

and confirmed that in the first instance, the printed `fba_launch` command includes the `--force_try_too_all` switch and in the second instance it does not.

My plan would be to merge this on Monday, hope (and expect) that `validate_lastnight_fba` still works, and then incorporate John's work from https://github.com/desihub/desitarget/pull/874. If something breaks, we will have the `--oldstyletoo` flag in reserve.

@dylanagreen: It would be great if you could take a quick look at this PR in the context of your related `fiberassign` work, but I think it should be simple (and safe).