### PR TITLE
replace pkg_resources with importlib.resources.files

### DIFF
--- a/py/desisurveyops/status_html.py
+++ b/py/desisurveyops/status_html.py
@@ -5,7 +5,6 @@ import os
 import textwrap
 from datetime import datetime, timedelta
 from time import time
-from pkg_resources import resource_filename
 
 # AR scientifical
 import numpy as np
@@ -21,6 +20,7 @@ from desisurveyops.status_utils import (
     get_programs_npassmaxs,
     get_shutdowns,
     get_history_tiles_infos,
+    get_history_tiles_dir,
     get_backup_minefftime,
     get_speed,
 )
@@ -63,7 +63,7 @@ def process_html(
 
     # AR need to copy the css?
     git_cssfn = os.path.join(
-        resource_filename("desisurveyops", "../../data"), os.path.basename(cssfn)
+        get_history_tiles_dir(), os.path.basename(cssfn)
     )
     if os.path.isfile(cssfn):
         f = open(cssfn, "r").read()

--- a/py/desisurveyops/status_utils.py
+++ b/py/desisurveyops/status_utils.py
@@ -7,9 +7,9 @@ matplotlib.use("Agg")
 import os
 from glob import glob
 from datetime import datetime
+from importlib.resources import files
 import tempfile
 import multiprocessing
-from pkg_resources import resource_filename
 import subprocess
 
 # AR scientifical
@@ -377,7 +377,7 @@ def get_history_tiles_dir():
     """
     Returns the folder with the tiles-{survey}-YYYYMMDD-rev?????.ecsv files.
     """
-    return resource_filename("desisurveyops", "../../data")
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "data"))
 
 
 def get_history_tilesfn(survey, opsnight=None):
@@ -574,7 +574,7 @@ def get_fns(
             "desi-14k-footprint",
             "desi-14k-footprint-dark.ecsv",
         ),
-        "desfoot": resource_filename("desiutil", "data/DES_footprint.txt"),
+        "desfoot": str(files("desiutil").joinpath("data", "DES_footprint.txt")),
     }
 
     # AR check?


### PR DESCRIPTION
Small fix to update desisurveyops code to modern standards that don't use `pkg_resources`. This was causing the code to crash with the new 2026 desiconda installation. This is a trivial change, so I'm self-merging.