### PR TITLE
Add DR11 1A tiles to the 1B reporting plots.

### DIFF
--- a/py/desisurveyops/status_qso.py
+++ b/py/desisurveyops/status_qso.py
@@ -113,6 +113,14 @@ def process_qso(
             "{}\tCompute qso stats".format(datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
         )
         sel = obs_progs == program
+
+        # DG - Add DR11 1A tiles on 1B  programs.
+        if "1B" in program:
+            # log.info("entered block")
+            dr11_1a_tiles = (obs_progs == program.replace("1B", ""))
+            dr11_1a_tiles &= obs_nights > 20260610
+            sel |= dr11_1a_tiles
+
         tileids, lastnights = obs_tiles[sel], obs_nights[sel]
         _ = np.char.add(tileids.astype(str), ",")
         tileids_lastnights = np.char.add(_, lastnights.astype(str))

--- a/py/desisurveyops/status_qso.py
+++ b/py/desisurveyops/status_qso.py
@@ -25,6 +25,7 @@ from desisurveyops.status_utils import (
     get_filename,
     get_fns,
     get_obsdone_tiles,
+    get_observed_tiles_from_program,
 )
 
 # AR desispec
@@ -112,14 +113,7 @@ def process_qso(
         log.info(
             "{}\tCompute qso stats".format(datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
         )
-        sel = obs_progs == program
-
-        # DG - Add DR11 1A tiles on 1B  programs.
-        if "1B" in program:
-            # log.info("entered block")
-            dr11_1a_tiles = (obs_progs == program.replace("1B", ""))
-            dr11_1a_tiles &= obs_nights > 20260610
-            sel |= dr11_1a_tiles
+        sel = get_observed_tiles_from_program(obs_progs, obs_nights, program)
 
         tileids, lastnights = obs_tiles[sel], obs_nights[sel]
         _ = np.char.add(tileids.astype(str), ",")

--- a/py/desisurveyops/status_qso.py
+++ b/py/desisurveyops/status_qso.py
@@ -25,7 +25,7 @@ from desisurveyops.status_utils import (
     get_filename,
     get_fns,
     get_obsdone_tiles,
-    get_observed_tiles_from_program,
+    get_observed_selection_from_program,
 )
 
 # AR desispec
@@ -113,7 +113,7 @@ def process_qso(
         log.info(
             "{}\tCompute qso stats".format(datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
         )
-        sel = get_observed_tiles_from_program(obs_progs, obs_nights, program)
+        sel = get_observed_selection_from_program(obs_progs, obs_nights, program)
 
         tileids, lastnights = obs_tiles[sel], obs_nights[sel]
         _ = np.char.add(tileids.astype(str), ",")

--- a/py/desisurveyops/status_sky.py
+++ b/py/desisurveyops/status_sky.py
@@ -606,20 +606,7 @@ def plot_skymap(
     if tilesfn is None:
         tilesfn = fns["ops"]["tiles"]
     t = Table.read(tilesfn)
-    sel = t["PROGRAM"] == program
-    sel &= t["IN_DESI"]
-    if skip_pass is not None:
-        sel &= ~np.isin(t["PASS"], skip_pass)
-
-    # DG - dr11 1a tiles that should be included in the 1b plots.
-    # TODO refactor such that the tiles are determined somewhere more globally.
-    if "1B" in program:
-        if program == "DARK1B":
-            dr11_tiles = ((t["TILEID"] >= 11962) & (t["TILEID"] <= 15688))
-        elif program == "BRIGHT1B":
-            dr11_tiles = ((t["TILEID"] >= 30993) & (t["TILEID"] <= 33654))
-        dr11_tiles &= t["IN_DESI"]
-        sel |= dr11_tiles
+    sel = get_tile_selection_from_program(t, program, in_desi=True, skip_pass=skip_pass)
 
     t = t[sel]
     passids = np.unique(t["PASS"])

--- a/py/desisurveyops/status_sky.py
+++ b/py/desisurveyops/status_sky.py
@@ -110,12 +110,23 @@ def process_skymap(
     max_numproc = 128
 
     for program, skip_pass, program_str in zip(programs, skip_passes, program_strs):
-
         # AR nights for this program
         sel = obs_progs == program
 
-        ## DG: Skip any passes we want, given a specific survey. Formerly
-        ## this comment indicated that we skip the low priority pass 5 in the
+        # DG - We want to report the dr11 added base BRIGHT/DARK tiles
+        # on the 1b program plots. These were added 6/11 so we look
+        # for 1a tiles and include a cut on that date. We must do this here
+        # first to ensure that we collect the correct nights to process.
+        # We will do it again in the actual plotting function to ensure
+        # we have the correct number of tiles on those nights.
+        if "1B" in program:
+            # log.info("entered block")
+            dr11_1a_tiles = (obs_progs == program.replace("1B", ""))
+            dr11_1a_tiles &= obs_nights > 20260610
+            sel |= dr11_1a_tiles
+
+        # DG: Skip any passes we want, given a specific survey. Formerly
+        # this comment indicated that we skip the low priority pass 5 in the
         # BRIGHT1B program.
         if skip_pass is not None:
             log.warning(f"For PROGRAM={program_str} ignoring PASS={skip_pass}")
@@ -161,7 +172,7 @@ def process_skymap(
                         ext="png",
                     )
                     log.info(f"{outpng = }")
-                    if (not os.path.isfile(outpng)) | (recompute):
+                    if (not os.path.isfile(outpng)) or (recompute):
                         myargs.append(
                             (
                                 outpng,
@@ -471,6 +482,12 @@ def create_skygoal(tilesfn, program, outfn=None, nside=1024, skip_pass=None):
     # AR tiles file
     t = Table.read(tilesfn)
     sel = t["PROGRAM"] == program
+    # DG - DR11 tiles for 1b programs. TODO: Refactor and do this better.
+    if program == "DARK1B":
+        sel |= ((t["TILEID"] >= 11962) & (t["TILEID"] <= 15688))
+    elif program == "BRIGHT1B":
+        sel |= ((t["TILEID"] >= 30993) & (t["TILEID"] <= 33654))
+
     sel &= t["IN_DESI"]
 
     if skip_pass is not None:
@@ -482,7 +499,7 @@ def create_skygoal(tilesfn, program, outfn=None, nside=1024, skip_pass=None):
     else:
         log.info("found {} tiles with PROGRAM = {}".format(len(t), program))
 
-    # AR handle e.g. BRIGHT1B which does not exist yet
+    # AR handle if a program does not exist yet or has no tiles.
     if len(t) == 0:
         log.warning("no tiles found for PROGRAM = {}, no file created".format(program))
         return None
@@ -603,14 +620,25 @@ def plot_skymap(
     if skip_pass is not None:
         sel &= ~np.isin(t["PASS"], skip_pass)
 
-    t = t[sel]
-    passids = np.unique(t["PASS"])
-    npass = len(passids)
-
     # AR obs/done tiles:
     # AR - obs : for this program and with obs_nights <= night
     # AR - done : for this program
     obs_tiles, obs_nights, obs_progs, done_tiles = get_obsdone_tiles(survey, specprod)
+
+    # DG - dr11 1a tiles that should be included in the 1b plots.
+    # TODO refactor such that the tiles are determined somewhere more globally.
+    if "1B" in program:
+        if program == "DARK1B":
+            dr11_tiles = ((t["TILEID"] >= 11962) & (t["TILEID"] <= 15688))
+        elif program == "BRIGHT1B":
+            dr11_tiles = ((t["TILEID"] >= 30993) & (t["TILEID"] <= 33654))
+        dr11_tiles &= t["IN_DESI"]
+        sel |= dr11_tiles
+
+    t = t[sel]
+    passids = np.unique(t["PASS"])
+    npass = len(passids)
+
     sel = np.isin(obs_tiles, t["TILEID"])
     sel &= obs_nights <= night
     obs_tiles, obs_nights, obs_progs = obs_tiles[sel], obs_nights[sel], obs_progs[sel]
@@ -626,6 +654,7 @@ def plot_skymap(
     d = get_skygoal(tilesfn, program, skip_pass=skip_pass)
     nside = d.meta["HPXNSIDE"]
     assert d.meta["HPXNEST"] == nest
+
     # AR to handle overlapping tiles in a single pass
     # AR for BRIGHT1B, first compute the per-tile pixels
     # AR note that tiles2pix() is not an exact solution

--- a/py/desisurveyops/status_sky.py
+++ b/py/desisurveyops/status_sky.py
@@ -32,6 +32,7 @@ from desisurveyops.status_utils import (
     get_expfacs,
     create_mp4,
     get_tile_selection_from_program,
+    get_observed_tiles_from_program,
 )
 
 # AR desimodel
@@ -112,19 +113,7 @@ def process_skymap(
 
     for program, skip_pass, program_str in zip(programs, skip_passes, program_strs):
         # AR nights for this program
-        sel = obs_progs == program
-
-        # DG - We want to report the dr11 added base BRIGHT/DARK tiles
-        # on the 1b program plots. These were added 6/11 so we look
-        # for 1a tiles and include a cut on that date. We must do this here
-        # first to ensure that we collect the correct nights to process.
-        # We will do it again in the actual plotting function to ensure
-        # we have the correct number of tiles on those nights.
-        if "1B" in program:
-            # log.info("entered block")
-            dr11_1a_tiles = (obs_progs == program.replace("1B", ""))
-            dr11_1a_tiles &= obs_nights > 20260610
-            sel |= dr11_1a_tiles
+        sel = get_observed_tiles_from_program(obs_progs, obs_nights, program)
 
         # DG: Skip any passes we want, given a specific survey. Formerly
         # this comment indicated that we skip the low priority pass 5 in the

--- a/py/desisurveyops/status_sky.py
+++ b/py/desisurveyops/status_sky.py
@@ -31,6 +31,7 @@ from desisurveyops.status_utils import (
     get_moon_radecphase,
     get_expfacs,
     create_mp4,
+    get_tile_selection_from_program,
 )
 
 # AR desimodel
@@ -481,17 +482,7 @@ def create_skygoal(tilesfn, program, outfn=None, nside=1024, skip_pass=None):
 
     # AR tiles file
     t = Table.read(tilesfn)
-    sel = t["PROGRAM"] == program
-    # DG - DR11 tiles for 1b programs. TODO: Refactor and do this better.
-    if program == "DARK1B":
-        sel |= ((t["TILEID"] >= 11962) & (t["TILEID"] <= 15688))
-    elif program == "BRIGHT1B":
-        sel |= ((t["TILEID"] >= 30993) & (t["TILEID"] <= 33654))
-
-    sel &= t["IN_DESI"]
-
-    if skip_pass is not None:
-        sel &= ~np.isin(t["PASS"], skip_pass)
+    sel = get_tile_selection_from_program(t, program, in_desi=True, skip_pass=skip_pass)
 
     t = t[sel]
     if skip_pass is not None:
@@ -1279,19 +1270,7 @@ def plot_skycompl_ralst(
     if tilesfn is None:
         tilesfn = fns["ops"]["tiles"]
     t = Table.read(tilesfn)
-    sel = t["PROGRAM"] == program
-
-
-    # DG - DR11 tiles for 1b programs. TODO: Refactor and do this better.
-    if program == "DARK1B":
-        sel |= ((t["TILEID"] >= 11962) & (t["TILEID"] <= 15688))
-    elif program == "BRIGHT1B":
-        sel |= ((t["TILEID"] >= 30993) & (t["TILEID"] <= 33654))
-
-    sel &= t["IN_DESI"]
-    if skip_pass is not None:
-        sel &= ~np.isin(t["PASS"], skip_pass)
-
+    sel = get_tile_selection_from_program(t, program, in_desi=True, skip_pass=skip_pass)
     t = t[sel]
 
     # AR cap
@@ -1499,15 +1478,7 @@ def plot_sky_pending(
     e = Table.read(fn)
     tilesfn = fns["ops"]["tiles"]
     t = Table.read(tilesfn)
-    sel = t["PROGRAM"] == program
-
-    # DG - DR11 tiles for 1b programs. TODO: Refactor and do this better.
-    if program == "DARK1B":
-        sel |= ((t["TILEID"] >= 11962) & (t["TILEID"] <= 15688))
-    elif program == "BRIGHT1B":
-        sel |= ((t["TILEID"] >= 30993) & (t["TILEID"] <= 33654))
-
-    sel &= t["IN_DESI"]
+    sel = get_tile_selection_from_program(t, program, in_desi=True)
     sel &= (t["STATUS"] != "unobs") & (t["STATUS"] != "done")
     if skip_pass is not None:
         sel &= ~np.isin(t["PASS"], skip_pass)

--- a/py/desisurveyops/status_sky.py
+++ b/py/desisurveyops/status_sky.py
@@ -620,11 +620,6 @@ def plot_skymap(
     if skip_pass is not None:
         sel &= ~np.isin(t["PASS"], skip_pass)
 
-    # AR obs/done tiles:
-    # AR - obs : for this program and with obs_nights <= night
-    # AR - done : for this program
-    obs_tiles, obs_nights, obs_progs, done_tiles = get_obsdone_tiles(survey, specprod)
-
     # DG - dr11 1a tiles that should be included in the 1b plots.
     # TODO refactor such that the tiles are determined somewhere more globally.
     if "1B" in program:
@@ -639,6 +634,10 @@ def plot_skymap(
     passids = np.unique(t["PASS"])
     npass = len(passids)
 
+    # AR obs/done tiles:
+    # AR - obs : for this program and with obs_nights <= night
+    # AR - done : for this program
+    obs_tiles, obs_nights, obs_progs, done_tiles = get_obsdone_tiles(survey, specprod)
     sel = np.isin(obs_tiles, t["TILEID"])
     sel &= obs_nights <= night
     obs_tiles, obs_nights, obs_progs = obs_tiles[sel], obs_nights[sel], obs_progs[sel]
@@ -1281,6 +1280,14 @@ def plot_skycompl_ralst(
         tilesfn = fns["ops"]["tiles"]
     t = Table.read(tilesfn)
     sel = t["PROGRAM"] == program
+
+
+    # DG - DR11 tiles for 1b programs. TODO: Refactor and do this better.
+    if program == "DARK1B":
+        sel |= ((t["TILEID"] >= 11962) & (t["TILEID"] <= 15688))
+    elif program == "BRIGHT1B":
+        sel |= ((t["TILEID"] >= 30993) & (t["TILEID"] <= 33654))
+
     sel &= t["IN_DESI"]
     if skip_pass is not None:
         sel &= ~np.isin(t["PASS"], skip_pass)
@@ -1493,6 +1500,13 @@ def plot_sky_pending(
     tilesfn = fns["ops"]["tiles"]
     t = Table.read(tilesfn)
     sel = t["PROGRAM"] == program
+
+    # DG - DR11 tiles for 1b programs. TODO: Refactor and do this better.
+    if program == "DARK1B":
+        sel |= ((t["TILEID"] >= 11962) & (t["TILEID"] <= 15688))
+    elif program == "BRIGHT1B":
+        sel |= ((t["TILEID"] >= 30993) & (t["TILEID"] <= 33654))
+
     sel &= t["IN_DESI"]
     sel &= (t["STATUS"] != "unobs") & (t["STATUS"] != "done")
     if skip_pass is not None:

--- a/py/desisurveyops/status_sky.py
+++ b/py/desisurveyops/status_sky.py
@@ -32,7 +32,7 @@ from desisurveyops.status_utils import (
     get_expfacs,
     create_mp4,
     get_tile_selection_from_program,
-    get_observed_tiles_from_program,
+    get_observed_selection_from_program,
 )
 
 # AR desimodel
@@ -113,7 +113,7 @@ def process_skymap(
 
     for program, skip_pass, program_str in zip(programs, skip_passes, program_strs):
         # AR nights for this program
-        sel = get_observed_tiles_from_program(obs_progs, obs_nights, program)
+        sel = get_observed_selection_from_program(obs_progs, obs_nights, program)
 
         # DG: Skip any passes we want, given a specific survey. Formerly
         # this comment indicated that we skip the low priority pass 5 in the

--- a/py/desisurveyops/status_utils.py
+++ b/py/desisurveyops/status_utils.py
@@ -1042,6 +1042,25 @@ def get_tile_selection_from_program(t, program, in_desi=True, skip_pass=None):
     return sel
 
 def get_observed_selection_from_program(obs_progs, obs_nights, program):
+    """
+    Get a boolean selection array for observed tiles belonging to a given program.
+
+    Args:
+        obs_progs: program name for each observed tile, as returned by get_obsdone_tiles() (numpy array of str)
+        obs_nights: night of observation for each observed tile, as returned by get_obsdone_tiles() (numpy array of int)
+        program: "BACKUP", "BRIGHT{1B}", or "DARK{1B}" (str)
+
+    Returns:
+        sel: boolean selection array over the rows of obs_progs/obs_nights (numpy array of bool)
+
+    Notes:
+        For BRIGHT1B or DARK1B, additionally includes tiles from the corresponding base program
+            (BRIGHT or DARK respectively) observed after night 20260610,
+            corresponding to 1A DR11 tiles added on 20260611.
+        Unlike get_tile_selection_from_program(), this function operates on the observed-tile
+            arrays from get_obsdone_tiles() rather than on a tiles table, and so uses the
+            observation night as a proxy for the tile timestamp.
+    """
     sel = obs_progs == program
 
     # DG - We want to report the dr11 added base BRIGHT/DARK tiles

--- a/py/desisurveyops/status_utils.py
+++ b/py/desisurveyops/status_utils.py
@@ -1024,6 +1024,12 @@ def get_tile_selection_from_program(t, program, in_desi=True, skip_pass=None):
     """
     sel = t["PROGRAM"] == program
 
+    # DG - skip pass before adding 1A tiles, so that we don't skip
+    # the same pass on the 1A tiles. That is, skip pass should only apply
+    # to the 1B program tiles if this is a 1B program.
+    if skip_pass is not None:
+        sel &= ~np.isin(t["PASS"], skip_pass)
+
     # DG - DR11 tiles for 1b programs.
     if program == "DARK1B":
         sel |= ((t["TILEID"] >= 11962) & (t["TILEID"] <= 15688))
@@ -1032,9 +1038,6 @@ def get_tile_selection_from_program(t, program, in_desi=True, skip_pass=None):
 
     if in_desi:
         sel &= t["IN_DESI"]
-
-    if skip_pass is not None:
-        sel &= ~np.isin(t["PASS"], skip_pass)
 
     return sel
 

--- a/py/desisurveyops/status_utils.py
+++ b/py/desisurveyops/status_utils.py
@@ -1004,6 +1004,24 @@ def get_speed(d, source):
     return speed
 
 def get_tile_selection_from_program(t, program, in_desi=True, skip_pass=None):
+    """
+    Get a boolean selection array for tiles belonging to a given program.
+
+    Args:
+        t: tile table, e.g. from reading tiles-{survey}.ecsv (astropy.table.Table)
+        program: "BACKUP", "BRIGHT{1B}", or "DARK{1B}" (str)
+        in_desi (optional, defaults to True): if True, additionally require IN_DESI=True (bool)
+        skip_pass (optional, defaults to None): if set, exclude tiles whose PASS is in skip_pass (list of int)
+
+    Returns:
+        sel: boolean selection array over the rows of t (numpy array of bool)
+
+    Notes:
+        For BRIGHT1B, additionally includes BRIGHT-program tiles with TILEID in [30993, 33654],
+            corresponding to 1A DR11 tiles added after 20260611.
+        For DARK1B, additionally includes DARK-program tiles with TILEID in [11962, 15688],
+            corresponding to 1A DR11 tiles added after 20260611.
+    """
     sel = t["PROGRAM"] == program
 
     # DG - DR11 tiles for 1b programs.

--- a/py/desisurveyops/status_utils.py
+++ b/py/desisurveyops/status_utils.py
@@ -352,7 +352,7 @@ def edit_history_tiles_file(night, revision, comment, survey='main'):
 
     return fn
 
-    
+
 def get_history_tiles_infos(survey):
     """
     Get infos about the history of tiles-{survey}.ecsv.
@@ -366,7 +366,7 @@ def get_history_tiles_infos(survey):
     d = Table.read(fn, format="ascii.ecsv")
 
     d.meta["FOLDER"] = os.path.dirname(fn)
-    
+
     # AR better safe than sorry...
     d = d[d["NIGHT"].argsort()]
 
@@ -381,7 +381,7 @@ def get_history_tiles_filename(survey):
         survey: survey name (str)
     """
     return os.path.join(get_history_tiles_dir(), f"tiles-{survey}-history.ecsv")
-    
+
 
 def get_history_tiles_dir():
     """
@@ -1002,3 +1002,22 @@ def get_speed(d, source):
         / d["EXPTIME"][sel]
     )
     return speed
+
+def get_tile_selection_from_program(t, program, in_desi=True, skip_pass=None):
+    sel = t["PROGRAM"] == program
+
+    # DG - DR11 tiles for 1b programs.
+    if program == "DARK1B":
+        sel |= ((t["TILEID"] >= 11962) & (t["TILEID"] <= 15688))
+    elif program == "BRIGHT1B":
+        sel |= ((t["TILEID"] >= 30993) & (t["TILEID"] <= 33654))
+
+    if in_desi:
+        sel &= t["IN_DESI"]
+
+    if skip_pass is not None:
+        sel &= ~np.isin(t["PASS"], skip_pass)
+
+    return sel
+
+

--- a/py/desisurveyops/status_utils.py
+++ b/py/desisurveyops/status_utils.py
@@ -1041,4 +1041,20 @@ def get_tile_selection_from_program(t, program, in_desi=True, skip_pass=None):
 
     return sel
 
+def get_observed_selection_from_program(obs_progs, obs_nights, program):
+    sel = obs_progs == program
+
+    # DG - We want to report the dr11 added base BRIGHT/DARK tiles
+    # on the 1b program plots. These were added 6/11 so we look
+    # for 1a tiles and include a cut on that date. We must do this here
+    # first to ensure that we collect the correct nights to process.
+    # We will do it again in the actual plotting function to ensure
+    # we have the correct number of tiles on those nights.
+    if "1B" in program:
+        # log.info("entered block")
+        dr11_1a_tiles = (obs_progs == program.replace("1B", ""))
+        dr11_1a_tiles &= obs_nights > 20260610
+        sel |= dr11_1a_tiles
+
+    return sel
 

--- a/py/desisurveyops/status_zhist.py
+++ b/py/desisurveyops/status_zhist.py
@@ -24,20 +24,15 @@ from desisurveyops.status_utils import (
     get_obsdone_tiles,
     table_read_for_pool,
     get_tile_selection_from_program,
+    get_observed_tiles_from_program
 )
 
 # AR desispec
 from desispec.tile_qa_plot import (
     get_qa_config,
-    get_zbins,
     get_tracer,
     get_zhists,
-    get_qa_badmsks,
-    get_quantz_cmap,
-    make_tile_qa_plot,
 )
-
-# AR fiberassgin
 
 # AR desiutil
 from desiutil.log import get_logger
@@ -45,7 +40,6 @@ from desiutil.log import get_logger
 # AR matplotlib
 import matplotlib
 import matplotlib.pyplot as plt
-from matplotlib import gridspec
 
 log = get_logger()
 
@@ -114,19 +108,8 @@ def process_zhist(
             rebin = 1
 
         # AR select the tiles
-        sel = obs_progs == program
-
-        if "1B" in program:
-            # log.info("entered block")
-            dr11_1a_tiles = (obs_progs == program.replace("1B", ""))
-            dr11_1a_tiles &= obs_nights > 20260610
-            sel |= dr11_1a_tiles
-
+        sel = get_observed_tiles_from_program(obs_progs, obs_nights, program)
         sel &= np.isin(obs_tiles, e["TILEID"])
-        # if npassmax is not None:
-        #     t = Table.read(out_fns["ops"]["tiles"])
-        #     t = t[t["PASS"] < npassmax]
-        #     sel &= np.isin(obs_tiles, t["TILEID"])
 
         # DG For any skip cases that get passed, e.g. skipping pass 5 in BRIGHT1B
         if skip_pass is not None:
@@ -136,7 +119,6 @@ def process_zhist(
             t = t[~np.isin(t["PASS"], skip_pass)]
             sel &= np.isin(obs_tiles, t["TILEID"])
 
-        # if npassmax is not None:
             log.info(f"found {sel.sum()} tiles with PROGRAM = {program} and SKIP_PASS {skip_pass}")
         else:
             log.info("found {} tiles with PROGRAM = {}".format(sel.sum(), program))

--- a/py/desisurveyops/status_zhist.py
+++ b/py/desisurveyops/status_zhist.py
@@ -115,6 +115,7 @@ def process_zhist(
 
         # AR select the tiles
         sel = obs_progs == program
+
         if "1B" in program:
             # log.info("entered block")
             dr11_1a_tiles = (obs_progs == program.replace("1B", ""))
@@ -204,8 +205,10 @@ def process_zhist(
             if key not in keys:
                 for d in ds:
                     d.meta[key] = None
-            else:
-                assert np.unique([d.meta[key] for d in ds]).size == 1
+            # DG - Remove this check, because when we added 1A DR11 tiles to 1B programs
+            # we naturally will have two values here e.g. BRIGHT and BRIGHT1B for FAPRGRM.
+            # else:
+            #     assert np.unique([d.meta[key] for d in ds]).size == 1
 
         # AR vstack + write
         d = vstack(ds)

--- a/py/desisurveyops/status_zhist.py
+++ b/py/desisurveyops/status_zhist.py
@@ -23,6 +23,7 @@ from desisurveyops.status_utils import (
     get_fns,
     get_obsdone_tiles,
     table_read_for_pool,
+    get_tile_selection_from_program,
 )
 
 # AR desispec
@@ -360,10 +361,7 @@ def plot_zhist(
 
     tilesfn = get_fns(survey=survey, specprod=specprod)["ops"]["tiles"]
     t = Table.read(tilesfn)
-    sel = t["PROGRAM"] == program
-    sel &= t["IN_DESI"]
-    if skip_pass is not None:
-        sel &= ~np.isin(t["PASS"], skip_pass)
+    sel = get_tile_selection_from_program(t, program, in_desi=True, skip_pass=skip_pass)
     t = t[sel]
 
     title = "{}/{}\n{}/{} (={:.0f}%) completed tiles up to {}".format(

--- a/py/desisurveyops/status_zhist.py
+++ b/py/desisurveyops/status_zhist.py
@@ -24,7 +24,7 @@ from desisurveyops.status_utils import (
     get_obsdone_tiles,
     table_read_for_pool,
     get_tile_selection_from_program,
-    get_observed_tiles_from_program
+    get_observed_selection_from_program
 )
 
 # AR desispec
@@ -108,7 +108,7 @@ def process_zhist(
             rebin = 1
 
         # AR select the tiles
-        sel = get_observed_tiles_from_program(obs_progs, obs_nights, program)
+        sel = get_observed_selection_from_program(obs_progs, obs_nights, program)
         sel &= np.isin(obs_tiles, e["TILEID"])
 
         # DG For any skip cases that get passed, e.g. skipping pass 5 in BRIGHT1B

--- a/py/desisurveyops/status_zhist.py
+++ b/py/desisurveyops/status_zhist.py
@@ -215,6 +215,8 @@ def process_zhist(
         d.meta["SURVEY"], d.meta["SPECPROD"] = survey, specprod
         d.write(outfn, overwrite=True)
 
+        log.info(f"Wrote {outfn}")
+
         # AR plot
         plot_zhist(
             outpng,
@@ -390,25 +392,25 @@ def plot_zhist(
         rebin_zcens = zcens.reshape((nbin // rebin, rebin)).mean(axis=1)
     else:
         rebin_zcens = zcens[:-remainder].reshape((nbin // rebin, rebin)).mean(axis=1)
-    nrebin = len(rebin_zcens)
-    tns = np.array(["{}-{}".format(t, n) for t, n in zip(d["TILEID"], d["LASTNIGHT"])])
-    unq_tns = np.unique(tns)
 
     for tracer, color in zip(tracers, colors):
-
-        # AR gather all zhists
         dd = d[d["TRACER"] == tracer]
-        assert len(dd) == unq_tns.size * nbin
-        hs = dd["ZHIST"].reshape((unq_tns.size, nbin))
-        nights = dd["LASTNIGHT"].reshape((unq_tns.size, nbin))[:, 0]
+
+        # DG - We must account for some tiles not having a tracer now that
+        # 1A DR11 DARK tiles are included in 1B plots, since LGE are not in the !A tiles.
+        tns_with_tracer = np.unique(dd["TILEID"])
+
+        assert len(dd) == tns_with_tracer.size * nbin
+        hs = dd["ZHIST"].reshape((tns_with_tracer.size, nbin))
+        nights = dd["LASTNIGHT"].reshape((tns_with_tracer.size, nbin))[:, 0]
 
         # AR rebin
         if remainder == 0:
-            rebin_hs = hs.reshape((unq_tns.size, nbin // rebin, rebin)).sum(axis=-1)
+            rebin_hs = hs.reshape((tns_with_tracer.size, nbin // rebin, rebin)).sum(axis=-1)
         else:
             rebin_hs = (
                 hs[:, :-remainder]
-                .reshape((unq_tns.size, nbin // rebin, rebin))
+                .reshape((tns_with_tracer.size, nbin // rebin, rebin))
                 .sum(axis=-1)
             )
 

--- a/py/desisurveyops/status_zhist.py
+++ b/py/desisurveyops/status_zhist.py
@@ -115,6 +115,12 @@ def process_zhist(
 
         # AR select the tiles
         sel = obs_progs == program
+        if "1B" in program:
+            # log.info("entered block")
+            dr11_1a_tiles = (obs_progs == program.replace("1B", ""))
+            dr11_1a_tiles &= obs_nights > 20260610
+            sel |= dr11_1a_tiles
+
         sel &= np.isin(obs_tiles, e["TILEID"])
         # if npassmax is not None:
         #     t = Table.read(out_fns["ops"]["tiles"])
@@ -122,7 +128,6 @@ def process_zhist(
         #     sel &= np.isin(obs_tiles, t["TILEID"])
 
         # DG For any skip cases that get passed, e.g. skipping pass 5 in BRIGHT1B
-
         if skip_pass is not None:
             log.warning(f"For PROGRAM={program_str} ignoring PASS={skip_pass}")
             fn = out_fns["ops"]["tiles"]


### PR DESCRIPTION
This PR adds 1A tiles to 1B plots where appropriate including:

- skymap, where tiles appear if they are observed but also in grey now if unobserved.
- qso, where the tiles are included in the qso computation for the 1b program to correctly report "qsos in the 1b era"
- zhist, where the tiles are included in the redshift histograms of the program, so now the histogram is "zhist in the 1b era".

This should be the only place necessary for these changes. 